### PR TITLE
Fix abstract to only input the html version

### DIFF
--- a/cnxpublishing/publish.py
+++ b/cnxpublishing/publish.py
@@ -26,7 +26,7 @@ ATTRIBUTED_ROLE_KEYS = (
 MODULE_INSERTION_TEMPLATE = """\
 WITH abstract_insertion AS (
   INSERT INTO abstracts (abstractid, abstract, html)
-  VALUES (DEFAULT, %(summary)s, %(summary)s)
+  VALUES (DEFAULT, NULL, %(summary)s)
   RETURNING abstractid),
 license_lookup AS (
   SELECT licenseid

--- a/cnxpublishing/tests/test_publish.py
+++ b/cnxpublishing/tests/test_publish.py
@@ -128,7 +128,7 @@ class PublishIntegrationTestCase(unittest.TestCase):
             with db_conn.cursor() as cursor:
                 cursor.execute("""\
 SELECT
-  m.name, m.language, a.abstract, l.url,
+  m.name, m.language, a.html AS abstract, l.url,
   m.major_version, m.minor_version,
   m.authors, m.submitter, m.submitlog, m.maintainers,
   m.licensors, m.parentauthors, m.google_analytics, m.buylink,

--- a/cnxpublishing/tests/use_cases.py
+++ b/cnxpublishing/tests/use_cases.py
@@ -63,7 +63,7 @@ BOOK = cnxepub.Binder(
         u'translators': [{u'id': u'frahablar',
                           u'name': u'Francis Hablar',
                           u'type': u'cnx-id'}],
-        u'summary': "<span>Book summary</span>",
+        u'summary': "<span xmlns='http://www.w3.org/1999/xhtml'>Book summary</span>",
         },
     nodes=[
         cnxepub.TranslucentBinder(
@@ -89,7 +89,7 @@ BOOK = cnxepub.Binder(
                                 u'subjects': [
                                     u'Mathematics and Statistics',
                                     ],
-                                u'summary': u'<span>descriptive text</span>',
+                                u'summary': u"<span xmlns='http://www.w3.org/1999/xhtml'>descriptive text</span>",
                                 u'language': u'en',
                                 u'license_text': u'CC-By 4.0',
                                 u'license_url': u'http://creativecommons.org/licenses/by/4.0/',
@@ -148,7 +148,7 @@ PAGE_ONE = cnxepub.Document(
         u'revised': u'2013/03/19 15:01:16 -0500',
         u'keywords': [u'South Africa'],
         u'subjects': [u'Science and Mathematics'],
-        u'summary': u'<span>descriptive text</span>',
+        u'summary': u"<span xmlns='http://www.w3.org/1999/xhtml'>descriptive text</span>",
         u'language': u'en',
         u'license_text': u'CC-By 4.0',
         u'license_url': u'http://creativecommons.org/licenses/by/4.0/',
@@ -191,7 +191,7 @@ PAGE_TWO = cnxepub.Document(
         u'revised': u'2013/03/19 15:01:16 -0500',
         u'keywords': [u'South Africa'],
         u'subjects': [u'Science and Mathematics'],
-        u'summary': u'<span>descriptive text</span>',
+        u'summary': u"<span xmlns='http://www.w3.org/1999/xhtml'>descriptive text</span>",
         u'language': u'en',
         u'license_text': u'CC-By 4.0',
         u'license_url': u'http://creativecommons.org/licenses/by/4.0/',
@@ -229,7 +229,7 @@ PAGE_THREE = cnxepub.Document(
         u'revised': u'2013/03/19 15:01:16 -0500',
         u'keywords': [u'South Africa'],
         u'subjects': [u'Science and Mathematics'],
-        u'summary': u'<span>descriptive text</span>',
+        u'summary': u"<span xmlns='http://www.w3.org/1999/xhtml'>descriptive text</span>",
         u'language': u'en',
         u'license_text': u'CC-By 4.0',
         u'license_url': u'http://creativecommons.org/licenses/by/4.0/',
@@ -267,7 +267,7 @@ PAGE_FOUR = cnxepub.Document(
         u'revised': u'2013/03/19 15:01:16 -0500',
         u'keywords': [u'South Africa'],
         u'subjects': [u'Science and Mathematics'],
-        u'summary': u'<span>descriptive text</span>',
+        u'summary': u"<span xmlns='http://www.w3.org/1999/xhtml'>descriptive text</span>",
         u'language': u'en',
         u'license_text': u'CC-By 4.0',
         u'license_url': u'http://creativecommons.org/licenses/by/4.0/',
@@ -307,7 +307,7 @@ PAGE_FIVE = cnxepub.Document(
         u'revised': u'2013/03/19 15:01:16 -0500',
         u'keywords': [u'South Africa'],
         u'subjects': [u'Science and Technology'],
-        u'summary': u'<span>descriptive text</span>',
+        u'summary': u"<span xmlns='http://www.w3.org/1999/xhtml'>descriptive text</span>",
         u'language': u'en',
         u'license_text': u'CC-By 4.0',
         u'license_url': u'http://creativecommons.org/licenses/by/4.0/',
@@ -361,7 +361,7 @@ COMPLEX_BOOK_ONE = cnxepub.Binder(
         u'translators': [{u'id': u'frahablar',
                           u'name': u'Francis Hablar',
                           u'type': u'cnx-id'}],
-        u'summary': "<span>Book summary</span>",
+        u'summary': "<span xmlns='http://www.w3.org/1999/xhtml'>Book summary</span>",
         },
     nodes=[
         cnxepub.TranslucentBinder(
@@ -406,7 +406,7 @@ COMPLEX_BOOK_TWO = cnxepub.Binder(
         u'translators': [{u'id': u'frahablar',
                           u'name': u'Francis Hablar',
                           u'type': u'cnx-id'}],
-        u'summary': "<span>Book summary</span>",
+        u'summary': "<span xmlns='http://www.w3.org/1999/xhtml'>Book summary</span>",
         },
     nodes=[
         cnxepub.TranslucentBinder(
@@ -442,7 +442,7 @@ COMPLEX_BOOK_THREE = cnxepub.Binder(
         u'publishers': [
             {u'id': u'ream', u'name': u'Ream', u'type': u'cnx-id'}],
         u'translators': [],
-        u'summary': "<span>Book summary</span>",
+        u'summary': "<span xmlns='http://www.w3.org/1999/xhtml'>Book summary</span>",
         },
     title_overrides=['D One', 'D Two'],
     nodes=[PAGE_TWO, PAGE_FOUR],


### PR DESCRIPTION
This was previously putting in html for the cnxml abstract value. The abstract column was previously required, and not used by legacy, so putting the html abstract in didn't cause any issues. However, now the abstract transform requires one of the columns to be empty before it will attempt a transform.

This also fixed the tests to include the now required html namespace.

Depends on Connexions/cnx-archive#285