### PR TITLE
Removing empty arrays from moduleoptionalroles table.  

### DIFF
--- a/cnxpublishing/publish.py
+++ b/cnxpublishing/publish.py
@@ -172,8 +172,25 @@ def _insert_metadata(cursor, model, publisher, message):
             '__moduleid__': "DEFAULT",
             })
 
+    ##################################
+    # FIXME : removal of empty       #
+    # editors and translators        #
+    # arrays should be handled       #
+    # when SQL stmt is generated     #
+    ##################################
+    if params['editors'] == []:
+        params['editors'] = None
+
+    if params['translators'] == []:
+        params['translators'] = None
+
     cursor.execute(stmt, params)
-    return cursor.fetchone()
+
+    ident_hash = cursor.fetchone()
+
+    cursor.execute("DELETE FROM moduleoptionalroles WHERE personids IS NULL")
+
+    return ident_hash
 
 
 def _insert_resource_file(cursor, module_ident, resource):


### PR DESCRIPTION
Modifying _insert_metadata function to remove rows with empty arrays from the moduleoptionalroles table.  Also moving tests for optional roles table entires into a single function.

Fix #74

Also related to...
Fix #75 