### PR TITLE
Persists user information during role entry and publication requests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,15 @@
+[run]
+source = cnxpublishing
+omit =
+    cnxpublishing/tests/*
+    cnxpublishing/scripts/*
+
+
+[report]
+exclude_lines =
+    pragma: no cover
+
+    if __name__ == .__main__.:
+omit =
+    cnxpublishing/scripts/*
+    cnxpublishing/tests/*

--- a/cnxpublishing/db.py
+++ b/cnxpublishing/db.py
@@ -171,6 +171,9 @@ WHERE id = %s""", (document_id,))
     acceptors = set([(uid, _role_type_to_db_type(type_),)
                      for uid, type_ in _dissect_roles(metadata)])
 
+    # Upsert the user info.
+    upsert_users(cursor, [x[0] for x in acceptors])
+
     # Acquire a list of existing acceptors.
     cursor.execute("""\
 SELECT user_id, role_type

--- a/cnxpublishing/db.py
+++ b/cnxpublishing/db.py
@@ -29,7 +29,10 @@ from pyramid.threadlocal import (
 
 from . import exceptions
 from .config import CONNECTION_STRING
-from .exceptions import ResourceFileExceededLimitError
+from .exceptions import (
+    ResourceFileExceededLimitError,
+    UserFetchError,
+    )
 from .utils import parse_archive_uri, parse_user_uri
 from .publish import publish_model, republish_binders
 
@@ -1127,6 +1130,67 @@ def remove_acl(cursor, uuid_, permissions):
 DELETE FROM document_acl
 WHERE uuid = %s AND user_id = %s AND permission = %s""",
                        (uuid_, uid, permission,))
+
+
+def _upsert_users(cursor, user_ids, lookup_func):
+    """Upsert's user info into the database.
+    The model contains the user info as part of the role values.
+    """
+    user_ids = list(set(user_ids))  # cleanse data
+
+    # Check for existing records to update.
+    cursor.execute("SELECT username from users where username = ANY (%s)",
+                   (user_ids,))
+    try:
+        existing_user_ids = [x[0] for x in cursor.fetchall()]
+    except TypeError:
+        existing_user_ids = []
+    new_user_ids = [u for u in user_ids if u not in existing_user_ids]
+
+    # Update existing records.
+    for user_id in existing_user_ids:
+        # TODO only update based on a delta against the 'updated' column.
+        user_info = lookup_func(user_id)
+        cursor.execute("""\
+UPDATE users
+SET (updated, username, first_name, last_name, full_name, title) =
+    (CURRENT_TIMESTAMP, %(username)s, %(first_name)s, %(last_name)s,
+     %(full_name)s, %(title)s)
+WHERE username = %(username)s""", user_info)
+
+    # Insert new records.
+    for user_id in new_user_ids:
+        user_info = lookup_func(user_id)
+        cursor.execute("""\
+INSERT INTO users
+(username, first_name, last_name, full_name, suffix, title)
+VALUES
+(%(username)s, %(first_name)s, %(last_name)s, %(full_name)s,
+ %(suffix)s, %(title)s)""", user_info)
+
+
+def upsert_users(cursor, user_ids):
+    """Given a set of user identifiers (``user_ids``),
+    upsert them into the database after checking accounts for
+    the latest information.
+    """
+    accounts = get_current_registry().getUtility(IOpenstaxAccounts)
+
+    def lookup_profile(username):
+        user_infos = accounts.global_search('username:{}'.format(username))
+        # See structure documentation at:
+        #   https://<accounts-instance>/api/docs/v1/users/index
+        count = user_infos['total_count']
+        if count > 1 or count == 0:
+            raise UserFetchError(username)
+        user_info = user_infos['items'][0]
+        opt_attrs = ('first_name', 'last_name', 'full_name',
+                     'title', 'suffix',)
+        for attr in opt_attrs:
+            user_info.setdefault(attr, None)
+        return user_info
+
+    _upsert_users(cursor, user_ids, lookup_profile)
 
 
 NOTIFICATION_TEMPLATE = jinja2.Template("""\

--- a/cnxpublishing/exceptions.py
+++ b/cnxpublishing/exceptions.py
@@ -8,6 +8,32 @@
 import json
 
 
+# ###################### #
+#   General Exceptions   #
+# ###################### #
+
+class UserFetchError(Exception):
+    """Raised when a user's info cannot be retrieved from the accounts system.
+    """
+
+    def __init__(self, user_id):
+        self.user_id = user_id
+
+    @property
+    def message(self):
+        msg = "User, named '{}', cannot be found in the accounts system." \
+            .format(self.user_id)
+        return msg
+
+    @property
+    def args(self):
+        return (self.message, self.__dict__,)
+
+
+# ########################## #
+#   Publication Exceptions   #
+# ########################## #
+
 class PublicationException(Exception):
     """Base class for more detailed exceptions.
     This exception is utilized when and only when a publication

--- a/cnxpublishing/tests/test_db.py
+++ b/cnxpublishing/tests/test_db.py
@@ -51,11 +51,8 @@ class BaseDatabaseIntegrationTestCase(unittest.TestCase):
         cls.db_conn_str = cls.settings[CONNECTION_STRING]
 
     def setUp(self):
-        accounts_config_key = archive_config.ACCOUNTS_CONNECTION_STRING
-        accounts_db_conn_str = self.settings[accounts_config_key]
         archive_settings = {
             archive_config.CONNECTION_STRING: self.db_conn_str,
-            archive_config.ACCOUNTS_CONNECTION_STRING: accounts_db_conn_str,
             }
         archive_initdb(archive_settings)
         from ..db import initdb

--- a/cnxpublishing/tests/test_db.py
+++ b/cnxpublishing/tests/test_db.py
@@ -548,6 +548,46 @@ ORDER BY user_id""", (uuid_,))
         self.assertEqual(entries, values)
 
 
+class RoleRequestTestCase(BaseDatabaseIntegrationTestCase):
+    """Verify user upsert functionality"""
+
+    def call_target(self, *args, **kwargs):
+        from ..db import upsert_users
+        return upsert_users(*args, **kwargs)
+
+    @db_connect
+    def test_success(self, cursor):
+        """upsert user info"""
+
+        # Create existing role records.
+        uids = ['charrose', 'frahablar', 'impicky', 'marknewlyn',
+                'ream', 'rings']
+        first_set_size = 3
+
+        # Call the target on the first group.
+        self.call_target(cursor, uids[:first_set_size])
+
+        # Check the additions.
+        cursor.execute("SELECT username FROM users ORDER BY username")
+        entries = [x[0] for x in cursor.fetchall()]
+        expected = uids[:first_set_size]
+        self.assertEqual(entries, expected)
+
+        # Call the target on the second group.
+        self.call_target(cursor, uids)
+
+        # Check the additions.
+        cursor.execute("SELECT username FROM users ORDER BY username")
+        entries = [x[0] for x in cursor.fetchall()]
+        self.assertEqual(entries, uids)
+
+    @db_connect
+    def test_fetch_error(self, cursor):
+        """Verify user fetch error"""
+        from ..db import UserFetchError
+        with self.assertRaises(UserFetchError) as caught_exc:
+            self.call_target(cursor, ['mia'])
+
 
 class DatabaseIntegrationTestCase(BaseDatabaseIntegrationTestCase):
     """Verify database interactions"""

--- a/cnxpublishing/tests/test_publish.py
+++ b/cnxpublishing/tests/test_publish.py
@@ -61,11 +61,8 @@ class PublishIntegrationTestCase(unittest.TestCase):
         cls.db_connect = staticmethod(db_connection_factory())
 
     def setUp(self):
-        accounts_config_key = archive_config.ACCOUNTS_CONNECTION_STRING
-        accounts_db_conn_str = self.settings[accounts_config_key]
         archive_settings = {
             archive_config.CONNECTION_STRING: self.db_conn_str,
-            archive_config.ACCOUNTS_CONNECTION_STRING: accounts_db_conn_str,
             }
         archive_initdb(archive_settings)
         from ..db import initdb
@@ -415,11 +412,8 @@ class RepublishTestCase(unittest.TestCase):
         cls.db_conn_str = cls.settings[CONNECTION_STRING]
 
     def setUp(self):
-        accounts_config_key = archive_config.ACCOUNTS_CONNECTION_STRING
-        accounts_db_conn_str = self.settings[accounts_config_key]
         archive_settings = {
             archive_config.CONNECTION_STRING: self.db_conn_str,
-            archive_config.ACCOUNTS_CONNECTION_STRING: accounts_db_conn_str,
             }
         archive_initdb(archive_settings)
         from ..db import initdb

--- a/cnxpublishing/tests/test_utils.py
+++ b/cnxpublishing/tests/test_utils.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+# ###
+# Copyright (c) 2015, Rice University
+# This software is subject to the provisions of the GNU Affero General
+# Public License version 3 (AGPLv3).
+# See LICENCE.txt for details.
+# ###
+import unittest
+
+
+class UtilsTests(unittest.TestCase):
+
+    def test_parse_archive_uri(self):
+        from ..utils import parse_archive_uri
+
+        faux_ident_hash = 'abc123@4'
+        ident_hash = parse_archive_uri('/contents/{}'.format(faux_ident_hash))
+        self.assertEqual(ident_hash, faux_ident_hash)
+
+    def test_parse_user_uri(self):
+        from ..utils import parse_user_uri
+
+        uid = 'typo'
+        user = parse_user_uri(uid, type_='cnx-id')
+        self.assertEqual(user, uid)
+
+        invalid_type = 'rice-id'
+        with self.assertRaises(ValueError) as caught_exc:
+            parse_user_uri(uid, type_=invalid_type)
+        self.assertEqual(
+            caught_exc.exception.args[0],
+            "Can't parse a user uri of type '{}'.".format(invalid_type))

--- a/cnxpublishing/tests/test_views.py
+++ b/cnxpublishing/tests/test_views.py
@@ -148,11 +148,8 @@ class BaseFunctionalViewTestCase(unittest.TestCase, EPUBMixInTestCase):
     def setUp(self):
         EPUBMixInTestCase.setUp(self)
         config = testing.setUp(settings=self.settings)
-        accounts_config_key = archive_config.ACCOUNTS_CONNECTION_STRING
-        accounts_db_conn_str = self.settings[accounts_config_key]
         archive_settings = {
             archive_config.CONNECTION_STRING: self.db_conn_str,
-            archive_config.ACCOUNTS_CONNECTION_STRING: accounts_db_conn_str,
             }
         archive_initdb(archive_settings)
         from ..db import initdb

--- a/cnxpublishing/utils.py
+++ b/cnxpublishing/utils.py
@@ -24,11 +24,7 @@ def parse_archive_uri(uri):
     """Given an archive URI, parse to a split ident-hash."""
     parsed = urlparse(uri)
     path = parsed.path.rstrip('/').split('/')
-    try:
-        ident_hash = path[-1]
-    except:
-        raise ValueError("Expected a path like /contents/{ident_hash}, "
-                         "got '{}' instead.".format(path))
+    ident_hash = path[-1]
     ident_hash = unquote(ident_hash)
     return ident_hash
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ install_requires = (
     'cnx-archive',
     'cnx-epub',
     'jinja2',
-    'openstax-accounts>=0.13.0',
+    'openstax-accounts>=0.14.0',
     'psycopg2',
     'pyramid>=1.5',
     'pyramid_multiauth',

--- a/testing.ini
+++ b/testing.ini
@@ -8,24 +8,17 @@ api-key-authnz =
 file-upload-limit = 1
 openstax_accounts.stub = true
 openstax_accounts.stub.users =
-  charrose,charrose
-  frahablar,frahablar
-  impicky,impicky
-  marknewlyn,marknewlyn
-  ream,ream
-  rings,rings
-  sarblyth,sarblyth
-  able,able
-  smoo,smoo
+  charrose,charrose,{"first_name": "Charrose", "last_name": "Esorrahc", "id": 0, "full_name": "Charrose Esorrahc", "title": null}
+  frahablar,frahablar,{"first_name": "Frahablar", "last_name": "Ralbaharf", "id": 1, "full_name": "Frahablar Ralbaharf", "title": null}
+  impicky,impicky,{"first_name": "Impicky", "last_name": "Ykcipmi", "id": 2, "full_name": "Impicky Ykcipmi", "title": null}
+  marknewlyn,marknewlyn,{"first_name": "Marknewlyn", "last_name": "Nylwenkram", "id": 3, "full_name": "Marknewlyn Nylwenkram", "title": null}
+  ream,ream,{"first_name": "Ream", "last_name": "Maer", "id": 4, "full_name": "Ream Maer", "title": null}
+  rings,rings,{"first_name": "Rings", "last_name": "Sgnir", "id": 5, "full_name": "Rings Sgnir", "title": null}
+  sarblyth,sarblyth,{"first_name": "Sarblyth", "last_name": "Htylbras", "id": 6, "full_name": "Sarblyth Htylbras", "title": null}
+  able,able,{"first_name": "Able", "last_name": "Elba", "id": 7, "full_name": "Able Elba", "title": null}
+  smoo,smoo,{"first_name": "Smoo", "last_name": "Ooms", "id": 8, "full_name": "Smoo Ooms", "title": null}
 openstax_accounts.stub.message_writer = memory
 openstax_accounts.application_url = http://localhost:8000/
 openstax_accounts.login_path = /login
 openstax_accounts.callback_path = /callback
 openstax_accounts.logout_path = /logout
-
-# ---
-# ONLY NEEDED for testing
-# ---
-
-# OpenStax Accounts database connection info
-accounts.fdw.db-connection-string = dbname=oscaccounts-testing host=localhost port=5432 user=accounts password=accounts


### PR DESCRIPTION
Depends on Connexions/openstax-accounts#16 & Connexions/cnx-archive#290

See also [trello card](https://trello.com/c/2Z2OEcSq/1116-convert-users-table-from-fdw-to-shadow-table)