### PR TITLE
Allow for shared username strings and inaccurate matching

### DIFF
--- a/cnxpublishing/db.py
+++ b/cnxpublishing/db.py
@@ -1183,10 +1183,15 @@ def upsert_users(cursor, user_ids):
         user_infos = accounts.global_search('username:{}'.format(username))
         # See structure documentation at:
         #   https://<accounts-instance>/api/docs/v1/users/index
-        count = user_infos['total_count']
-        if count > 1 or count == 0:
+        user_info = None
+        for item in user_infos['items']:
+            if item['username'] == username:
+                # Ensure an exact match.
+                user_info = item
+                break
+        if user_info is None:
             raise UserFetchError(username)
-        user_info = user_infos['items'][0]
+
         opt_attrs = ('first_name', 'last_name', 'full_name',
                      'title', 'suffix',)
         for attr in opt_attrs:

--- a/cnxpublishing/tests/test_db.py
+++ b/cnxpublishing/tests/test_db.py
@@ -548,7 +548,7 @@ ORDER BY user_id""", (uuid_,))
         self.assertEqual(entries, values)
 
 
-class RoleRequestTestCase(BaseDatabaseIntegrationTestCase):
+class UserUpsertTestCase(BaseDatabaseIntegrationTestCase):
     """Verify user upsert functionality"""
 
     def call_target(self, *args, **kwargs):
@@ -561,7 +561,7 @@ class RoleRequestTestCase(BaseDatabaseIntegrationTestCase):
 
         # Create existing role records.
         uids = ['charrose', 'frahablar', 'impicky', 'marknewlyn',
-                'ream', 'rings']
+                'ream', 'rings', 'smoo']
         first_set_size = 3
 
         # Call the target on the first group.
@@ -574,12 +574,21 @@ class RoleRequestTestCase(BaseDatabaseIntegrationTestCase):
         self.assertEqual(entries, expected)
 
         # Call the target on the second group.
-        self.call_target(cursor, uids)
+        self.call_target(cursor, uids[:-1])
 
         # Check the additions.
         cursor.execute("SELECT username FROM users ORDER BY username")
         entries = [x[0] for x in cursor.fetchall()]
-        self.assertEqual(entries, uids)
+        self.assertEqual(entries, uids[:-1])
+
+        # Check for similar usernames.
+        # ... smoo & smoopy
+        self.call_target(cursor, uids[-1:])
+
+        # Check the additions.
+        cursor.execute("SELECT username FROM users ORDER BY username")
+        entries = [x[0] for x in cursor.fetchall()]
+        self.assertIn(uids[-1], entries)
 
     @db_connect
     def test_fetch_error(self, cursor):

--- a/testing.ini
+++ b/testing.ini
@@ -17,6 +17,7 @@ openstax_accounts.stub.users =
   sarblyth,sarblyth,{"first_name": "Sarblyth", "last_name": "Htylbras", "id": 6, "full_name": "Sarblyth Htylbras", "title": null}
   able,able,{"first_name": "Able", "last_name": "Elba", "id": 7, "full_name": "Able Elba", "title": null}
   smoo,smoo,{"first_name": "Smoo", "last_name": "Ooms", "id": 8, "full_name": "Smoo Ooms", "title": null}
+  smoopy,smoopy,{"first_name": "Smoopy", "last_name": "Ypooms", "id": 9, "full_name": "Smoopy Ypooms", "title": null}
 openstax_accounts.stub.message_writer = memory
 openstax_accounts.application_url = http://localhost:8000/
 openstax_accounts.login_path = /login


### PR DESCRIPTION
Since the search is not an exact match on username, the username could share characters with another or match partially. For example, 'snoop' and 'snoopy' would show up in a search for 'snoop'. Likewise, 'snoop' and 'snoopy' would be found in a search for 'snoo'.