### PR TITLE
removing the 'cnx.org' condition for invalid reference.uri strings

### DIFF
--- a/cnxpublishing/db.py
+++ b/cnxpublishing/db.py
@@ -556,10 +556,7 @@ def add_pending_model_content(cursor, publication_id, model):
                         reference.bind(doc_pointer, "/contents/{}")
                 else:
                     mark_invalid_reference(reference)
-            # This will check cnx.org and openstaxcnx.org.
-            elif reference.uri_parts.netloc.find('cnx.org') >= 0:
-                mark_invalid_reference(reference)
-            # else, it's a remote reference... Do nothing.
+            # else, it's a remote or cnx.org reference ...Do nothing.
 
         args = (psycopg2.Binary(model.content.encode('utf-8')),
                 publication_id, model.id,)

--- a/cnxpublishing/tests/test_db.py
+++ b/cnxpublishing/tests/test_db.py
@@ -977,16 +977,19 @@ VALUES
         content = """
             <!-- Invalid references -->
             <img src="../resources/8bef27ba.png"/>
+            <a href="/contents/765792e0-5e65-4411-88d3-90df8f48eb3a@55">
+              relative reference to internal content that does not exist
+            </a>
+            <!-- Valid reference -->
             <a href="http://openstaxcnx.org/contents/8bef27ba@55">
               external reference to internal content
             </a>
             <a href="http://cnx.org/contents/8bef27ba@55">
               external reference to internal content
             </a>
-            <a href="/contents/765792e0-5e65-4411-88d3-90df8f48eb3a@55">
-              relative reference to internal content that does not exist
+             <a href="http://demo.cnx.org/images/logo.png">
+              external reference to internal content
             </a>
-            <!-- Valid reference -->
             <a href="/contents/{}">
               relative reference to internal content
             </a>
@@ -1032,7 +1035,7 @@ WHERE id = %s""", (publication_id,))
             u'xpath': xpath,
             u'value': ref_value,
             }
-        self.assertEqual(len(state_messages), 4)
+        self.assertEqual(len(state_messages), 2)
         self.assertEqual(state_messages[-1], expected_state_message)
 
     @db_connect


### PR DESCRIPTION
Fixes #71 