### PR TITLE
Add a moderation interface

### DIFF
--- a/cnxpublishing/db.py
+++ b/cnxpublishing/db.py
@@ -9,6 +9,7 @@ from __future__ import print_function
 import os
 import sys
 import io
+import functools
 import json
 import uuid
 
@@ -74,6 +75,24 @@ def initdb(connection_string):
                         print("File '{}' had issues executing." \
                               .format(schema_filepath), file=sys.stderr)
                         raise
+
+
+def with_db_cursor(func):
+    """Decorator that supplies a cursor to the function.
+    This passes in a psycopg2 Cursor as the keyword argument 'cursor'.
+    """
+
+    @functools.wraps(func)
+    def wrapped(*args, **kwargs):
+        registry = get_current_registry()
+        conn_str = registry.settings[CONNECTION_STRING]
+        with psycopg2.connect(conn_str) as db_connection:
+            with db_connection.cursor() as cursor:
+                kwargs['cursor'] = cursor
+                return func(*args, **kwargs)
+
+    return wrapped
+
 
 # FIXME Cache the database query in this function. Cache for forever.
 # TODO Move to cnx-archive.
@@ -734,90 +753,82 @@ SET (license_accepted, roles_accepted) = (%s, %s)
 WHERE id = %s""",
                    args)
 
-
-def poke_publication_state(publication_id, current_state=None):
+@with_db_cursor
+def poke_publication_state(publication_id, cursor):
     """Invoked to poke at the publication to update and acquire its current
     state. This is used to persist the publication to archive.
     """
-    registry = get_current_registry()
-    conn_str = registry.settings[CONNECTION_STRING]
-    with psycopg2.connect(conn_str) as db_conn:
-        with db_conn.cursor() as cursor:
-            if current_state is None:
-                cursor.execute("""\
-SELECT "state", "state_messages", "is_pre_publication"
+    cursor.execute("""\
+SELECT "state", "state_messages", "is_pre_publication", "publisher"
 FROM publications
 WHERE id = %s""", (publication_id,))
-                current_state, messages, is_pre_publication = cursor.fetchone()
+    row = cursor.fetchone()
+    current_state, messages, is_pre_publication, publisher = row
+
     if current_state in ('Publishing', 'Done/Success', 'Failed/Error',):
         # Bailout early, because the publication is either in progress
         # or has been completed.
         return current_state, messages
 
     # Check for acceptance...
-    with psycopg2.connect(conn_str) as db_conn:
-        with db_conn.cursor() as cursor:
-            cursor.execute("""\
+    cursor.execute("""\
 SELECT
   pd.id, license_accepted, roles_accepted
 FROM publications AS p JOIN pending_documents AS pd ON p.id = pd.publication_id
 WHERE p.id = %s
-""",
-                           (publication_id,))
-            pending_document_states = cursor.fetchall()
-            publication_state_mapping = {}
-            for document_state in pending_document_states:
-                id, is_license_accepted, are_roles_accepted = document_state
-                publication_state_mapping[id] = [is_license_accepted,
-                                                 are_roles_accepted]
-                has_changed_state = False
-                if is_license_accepted and are_roles_accepted:
-                    continue
-                elif not is_license_accepted:
-                    accepted = _check_pending_document_license_state(
-                        cursor, id)
-                    if accepted != is_license_accepted:
-                        has_changed_state = True
-                        is_license_accepted = accepted
-                        publication_state_mapping[id][0] = accepted
-                elif not are_roles_accepted:
-                    accepted = _check_pending_document_role_state(
-                        cursor, id)
-                    if accepted != are_roles_accepted:
-                        has_changed_state = True
-                        are_roles_accepted = accepted
-                        publication_state_mapping[id][1] = accepted
-                if has_changed_state:
-                    _update_pending_document_state(cursor, id,
-                                                   is_license_accepted,
-                                                   are_roles_accepted)
+""", (publication_id,))
+    pending_document_states = cursor.fetchall()
+    publication_state_mapping = {}
+    for document_state in pending_document_states:
+        id, is_license_accepted, are_roles_accepted = document_state
+        publication_state_mapping[id] = [is_license_accepted,
+                                         are_roles_accepted]
+        has_changed_state = False
+        if is_license_accepted and are_roles_accepted:
+            continue
+        elif not is_license_accepted:
+            accepted = _check_pending_document_license_state(
+                cursor, id)
+            if accepted != is_license_accepted:
+                has_changed_state = True
+                is_license_accepted = accepted
+                publication_state_mapping[id][0] = accepted
+        elif not are_roles_accepted:
+            accepted = _check_pending_document_role_state(
+                cursor, id)
+            if accepted != are_roles_accepted:
+                has_changed_state = True
+                are_roles_accepted = accepted
+                publication_state_mapping[id][1] = accepted
+        if has_changed_state:
+            _update_pending_document_state(cursor, id,
+                                           is_license_accepted,
+                                           are_roles_accepted)
 
     # Are all the documents ready for publication?
     state_lump = set([l and r for l, r in publication_state_mapping.values()])
     is_publish_ready = not (False in state_lump) and not (None in state_lump)
 
     # Publish the pending documents.
-    with psycopg2.connect(conn_str) as db_conn:
-        with db_conn.cursor() as cursor:
-            if is_publish_ready:
-                if not is_pre_publication:
-                    publication_state = publish_pending(cursor, publication_id)
-                else:
-                    change_state = "Done/Success"
-                    cursor.execute("""\
+    if is_publish_ready:
+        if not is_pre_publication:
+            publication_state = publish_pending(cursor, publication_id)
+        else:
+            change_state = "Done/Success"
+            cursor.execute("""\
 UPDATE publications
 SET state = %s
 WHERE id = %s
 RETURNING state, state_messages""", (change_state, publication_id,))
-                    publication_state, messages = cursor.fetchone()
-            else:
-                change_state = "Waiting for acceptance"
-                cursor.execute("""\
+            publication_state, messages = cursor.fetchone()
+    else:
+        change_state = "Waiting for acceptance"
+        cursor.execute("""\
 UPDATE publications
 SET state = %s
 WHERE id = %s
 RETURNING state, state_messages""", (change_state, publication_id,))
-                publication_state, messages = cursor.fetchone()
+        publication_state, messages = cursor.fetchone()
     return publication_state, messages
 
 

--- a/cnxpublishing/main.py
+++ b/cnxpublishing/main.py
@@ -45,20 +45,11 @@ def declare_api_routes(config):
     # Moderation routes
     add_route('moderation', '/moderations')
     add_route('moderate', '/moderations/{id}')
+    add_route('moderation-rss', '/feeds/moderations.rss')
 
 
 def declare_browsable_routes(config):
     """Declaration of routes that can be browsed by users."""
-    config.include('pyramid_jinja2')
-    config.add_jinja2_renderer('.html')
-    config.add_static_view(name='static', path="cnxpublishing:static/")
-    # Place a few globals in the template environment.
-    config.commit()
-    jinja2_env = config.get_jinja2_environment('.html')
-    jinja2_env.globals.update(
-        join_ident_hash=join_ident_hash,
-        )
-
     # This makes our routes slashed, which is good browser behavior.
     config.add_notfound_view(default_exceptionresponse_view,
                              append_slash=True)
@@ -70,6 +61,18 @@ def declare_browsable_routes(config):
 
 def declare_routes(config):
     """Declare all routes."""
+    config.include('pyramid_jinja2')
+    config.add_jinja2_renderer('.html')
+    config.add_jinja2_renderer('.rss')
+    config.add_static_view(name='static', path="cnxpublishing:static/")
+    # Place a few globals in the template environment.
+    config.commit()
+    for ext in ('.html', '.rss',):
+        jinja2_env = config.get_jinja2_environment(ext)
+        jinja2_env.globals.update(
+            join_ident_hash=join_ident_hash,
+            )
+
     declare_api_routes(config)
     declare_browsable_routes(config)
 

--- a/cnxpublishing/sql/schema-tables.sql
+++ b/cnxpublishing/sql/schema-tables.sql
@@ -8,9 +8,10 @@
 
 CREATE TABLE publications (
   "id" SERIAL PRIMARY KEY,
+  "created" TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
   "publisher" TEXT NOT NULL,
   "publication_message" TEXT NOT NULL,
-  "epub" BYTEA NOT NULL,
+  "epub" BYTEA,
   -- Pre-publication, do not commit to *archive*.
   "is_pre_publication" BOOLEAN DEFAULT FALSE,
   -- State information, included an optional message.

--- a/cnxpublishing/sql/schema-types.sql
+++ b/cnxpublishing/sql/schema-types.sql
@@ -12,7 +12,8 @@ CREATE TYPE publication_states AS ENUM (
   'Processing',  -- Processing any part of the publication.
   'Waiting for acceptance',
   'Failed/Error',
-  'Waiting for moderation'  -- Needs moderator approval
+  'Waiting for moderation',  -- Needs moderator approval
+  'Rejected' -- A moderator rejected the publication
 );
 
 

--- a/cnxpublishing/sql/schema-types.sql
+++ b/cnxpublishing/sql/schema-types.sql
@@ -11,7 +11,8 @@ CREATE TYPE publication_states AS ENUM (
   'Publishing',  -- In the process of committing.
   'Processing',  -- Processing any part of the publication.
   'Waiting for acceptance',
-  'Failed/Error'
+  'Failed/Error',
+  'Waiting for moderation'  -- Needs moderator approval
 );
 
 

--- a/cnxpublishing/templates/base.html
+++ b/cnxpublishing/templates/base.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html class="no-js" lang="">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <title></title>
+    <meta name="description" content="">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <link rel="stylesheet" href="/static/css/normalize.min.css">
+    <link rel="stylesheet" href="/static/css/main.css">
+
+    <script src="/static/js/vendor/modernizr-2.8.3.min.js"></script>
+    {% block head %}
+    {% endblock %}
+  </head>
+  <body>
+    <div id='content'>
+      {% block content %}
+      {% endblock %}
+    </div>
+
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
+    <script>window.jQuery || document.write('<script src="/static/js/vendor/jquery-1.11.2.min.js"><\/script>')</script>
+
+    <script src="/static/js/plugins.js"></script>
+    <script src="/static/js/main.js"></script>
+    <script>
+      {% block script %}
+      {% endblock %}
+    </script>
+  </body>
+</html>

--- a/cnxpublishing/templates/index.html
+++ b/cnxpublishing/templates/index.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% block content %}
+  <h1>Navigation</h1>
+  <ul>
+  {% for nav_item in navigation %}
+    <li><a href="{{ nav_item.uri }}">{{ nav_item.name }}</a></li>
+  {% endfor %}
+  </ul>
+{% endblock %}

--- a/cnxpublishing/templates/moderations.html
+++ b/cnxpublishing/templates/moderations.html
@@ -1,0 +1,61 @@
+{% extends "base.html" %}
+{% block content %}
+  <h1>Moderation List</h1>
+  <table>
+    <tr>
+      <th>Publication ID</th>
+      <th>Created</th>
+      <th>Publisher</th>
+      <th>Publication message</th>
+      <th>Models</th>
+      <th>Accept?</th>
+    </tr>
+    {% for pub in moderations %}
+      <tr id="{{ pub.id ~ '-row' }}">
+        <td>{{ pub.id }}</td>
+        <td>{{ pub.created }}</td>
+        <td>{{ pub.publisher }}</td>
+        <td>{{ pub.publication_message }}</td>
+        <td>
+          <ul>
+            {% for item in pub.models %}
+              <li>
+                <span class="{{ item.type }}">{{ item.type[0] }}</span>
+                <a href="{{ request.route_url('get-content', ident_hash=join_ident_hash(item.uuid, (item.major_version, item.minor_version,))) }}">
+                  {{ item.metadata.title }}
+                </a>
+              </li>
+            {% endfor %}
+          </ul>
+        </td>
+        <td>
+          <button name="{{ pub.id }}" value="accept">Accept</button>
+          <button name="{{ pub.id }}" value="reject">Reject</button>
+        </td>
+      </tr>
+    {% endfor %}
+  </table>
+{% endblock %}
+{% block script %}
+$(document).ready(function($) {
+  $('button').each(function(idx) {
+    $(this).click(function(e) {
+      console.log('moo')
+      var url = '/moderations/' + this.name,
+          isAccepted = this.value === 'accept',
+          pubId = this.name;
+      console.log("Button clicked: " + isAccepted);
+      $.ajax({
+        url: url,
+        type: 'POST',
+        contentType: 'application/json',
+        data: JSON.stringify({'is_accepted': isAccepted})
+      })
+      .done(function(data, textStatus, xhr) {
+        $('#' + pubId + '-row').remove();
+      });
+      return false;
+    });
+  });
+});
+{% endblock %}

--- a/cnxpublishing/templates/moderations.rss
+++ b/cnxpublishing/templates/moderations.rss
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<rss version="2.0">
+<channel>
+  <title>Publishing Moderation List</title>
+  <link>{{ request.route_url('admin-moderation') }}</link>
+  <description></description>
+  {% for pub in moderations %}
+    <item>
+      <title>Publication #{{ pub.id }}</title>
+      <link>{{ request.route_url('admin-moderation') }}</link>
+      <description>
+        &lt;span&gt;Created: {{ pub.created }}&lt;/span&gt;
+        &lt;br/&gt;
+        &lt;span&gt;By: {{ pub.publisher }}&lt;/span&gt;
+        &lt;br/&gt;
+        &lt;span&gt;Message: {{ pub.publication_message }}&lt;/span&gt;
+        &lt;br/&gt;
+        &lt;div&gt;
+          &lt;ul&gt;
+            {% for item in pub.models %}
+              &lt;li&gt;
+                &lt;span class="{{ item.type }}"&gt;{{ item.type[0] }}&lt;/span&gt;
+                &lt;a href="{{ request.route_url('get-content', ident_hash=join_ident_hash(item.uuid, (item.major_version, item.minor_version,))) }}"&gt;
+                  {{ item.metadata.title }}
+                &lt;/a&gt;
+              &lt;/li&gt;
+            {% endfor %}
+          &lt;/ul&gt;
+        &lt;/div&gt;
+      </description>
+    </item>
+  {% endfor %}
+</channel>
+</rss>

--- a/cnxpublishing/tests/test_views.py
+++ b/cnxpublishing/tests/test_views.py
@@ -757,7 +757,9 @@ class PublishingAPIFunctionalTestCase(BaseFunctionalViewTestCase):
            - As [an attributed role], accept my attribution
              on these documents/binders in this publication.
 
-        4. Verify documents are in the archive. [HACKED]
+        4. Wait for moderation acceptance from a moderator.
+
+        5. Verify documents are in the archive. [HACKED]
 
         """
         publisher = u'ream'
@@ -874,13 +876,25 @@ GROUP BY user_id, accepted
                                       "role attribution.".format(user_id)
                     self.assertTrue(has_accepted, failure_message)
 
+        # 4. (manual)
+        # FIXME This needs to be done as a moderator and directly
+        #       calling the route.
+        # Assume moderation acceptance && Manually call poke
+        with self.db_connect() as db_conn:
+            with db_conn.cursor() as cursor:
+                cursor.execute("""\
+UPDATE users SET (is_moderated) = ('t')
+WHERE username = %s""", (publisher,))
+        from ..db import poke_publication_state
+        poke_publication_state(publication_id)
+
         # *. --
         # This is publication completion,
         # because all licenses and roles have been accepted.
         self.app_check_state(publication_id, 'Done/Success',
                              headers=api_key_headers)
 
-        # 4. (manual)
+        # 5. (manual)
         self._check_published_to_archive(use_cases.BOOK)
 
     def test_new_to_pre_publication(self):
@@ -1014,6 +1028,10 @@ GROUP BY user_id, accepted
         Publish *revised* documents.
         This includes application and user interactions with publishing.
 
+        Note, the original publication was done by the user, 'rings',
+        while this one is done by 'ream'. 'reams' has vouched for 'rings',
+        which means moderation won't be necessary.
+
         *. After each step, check the state of the publication.
 
         1. Submit an EPUB containing a book of documents.
@@ -1040,6 +1058,156 @@ GROUP BY user_id, accepted
                                        u'públishing this book')
         api_key = self.api_keys_by_uid['no-trust']
         api_key_headers = [('x-api-key', api_key,)]
+
+        # Moderation is not required, because the publisher is already
+        #   vetted by having previously been attributed on one or more
+        #   published documents.
+
+        # 1. --
+        resp = self.app_post_publication(epub_filepath,
+                                         headers=api_key_headers)
+        self.assertEqual(resp.json['state'], 'Waiting for acceptance')
+        publication_id = resp.json['publication']
+
+        # *. --
+        self.app_check_state(publication_id, 'Waiting for acceptance',
+                             headers=api_key_headers)
+
+        # 2. --
+        # TODO This uses the JSON get/post parts; revision publications
+        #      should attempt to use the HTML form.
+        #      Check the form contains for the correct documents and default
+        #      values. This is going to be easier to look
+        #      at and verify in a revision publication, where we can depend
+        #      on known uuid values.
+        uids = (
+            'charrose', 'frahablar', 'impicky', 'marknewlyn', 'ream',
+            'rings', 'sarblyth',
+            )
+        for uid in uids:
+            # -- Check the form has the correct values.
+            resp = self.app_get_license_acceptance(
+                publication_id, uid,
+                headers=[('Accept', 'application/json',)])
+            acceptance_data = resp.json
+            document_acceptance_data = [e for e in acceptance_data['documents']]
+            for doc_record in document_acceptance_data:
+                doc_record[u'is_accepted'] = True
+            acceptance_data['documents'] = document_acceptance_data
+            resp = self.app_post_json_license_acceptance(
+                publication_id, uid, acceptance_data)
+        # -- (manual) Check the records for acceptance.
+        with self.db_connect() as db_conn:
+            with db_conn.cursor() as cursor:
+                cursor.execute("""
+SELECT user_id, accepted
+FROM license_acceptances
+GROUP BY user_id, accepted
+""")
+                acceptance_records = cursor.fetchall()
+                for user_id, has_accepted in acceptance_records:
+                    failure_message = "{} has not accepted " \
+                                      "the licenses.".format(user_id)
+                    self.assertTrue(has_accepted, failure_message)
+
+        # *. --
+        self.app_check_state(publication_id, 'Waiting for acceptance',
+                             headers=api_key_headers)
+
+        # 3. --
+        for uid in uids:
+            # -- Check the form has the correct values.
+            resp = self.app_get_role_acceptance(
+                publication_id, uid,
+                headers=[('Accept', 'application/json',)])
+            acceptance_data = resp.json
+            document_acceptance_data = [e for e in acceptance_data['documents']]
+            for doc_record in document_acceptance_data:
+                doc_record[u'is_accepted'] = True
+            acceptance_data['documents'] = document_acceptance_data
+            resp = self.app_post_json_role_acceptance(
+                publication_id, uid, acceptance_data)
+        # -- (manual) Check the records for acceptance.
+        with self.db_connect() as db_conn:
+            with db_conn.cursor() as cursor:
+                cursor.execute("""
+SELECT user_id, accepted
+FROM role_acceptances
+GROUP BY user_id, accepted
+""")
+                acceptance_records = cursor.fetchall()
+                for user_id, has_accepted in acceptance_records:
+                    failure_message = "{} has not accepted " \
+                                      "role attribution.".format(user_id)
+                    self.assertTrue(has_accepted, failure_message)
+
+        # *. --
+        # This is publication completion,
+        # because all licenses and roles have been accepted.
+        self.app_check_state(publication_id, 'Done/Success',
+                             headers=api_key_headers)
+
+        # 4. (manual)
+        self._check_published_to_archive(use_cases.REVISED_BOOK)
+
+    def test_revision_w_new_vetted_publisher(self):
+        """\
+        Publish *revised* documents as a *new publisher*.
+        This includes application and user interactions with publishing.
+
+        Note, the original publication was done by the user, 'rings',
+        while this one is done by 'ream'. The moderation of this
+        publication has been done by 'reams'.
+
+        The new publisher 'able' is not a member of any published content.
+        Therefore, 'able' has not been *moderated* for publications.
+        However, by virtue of being added as a publisher to this content
+        'able' has been vetted by someone on the content. This only
+        works if one or more of the published documents are a revision.
+
+        *. After each step, check the state of the publication.
+
+        1. Submit an EPUB containing a book of documents.
+
+        2. For each *attributed role*...
+
+           - As the publisher, accept the license.
+           - As the copyright-holder, accept the license.
+           - As [other attributed roles], accept the license.
+
+        3. For each *attributed role*...
+
+           - As [an attributed role], accept my attribution
+             on these documents/binders in this publication.
+
+        4. Verify documents are in the archive. [HACKED]
+
+        """
+        # Insert the BOOK use-case in order to make a revision of it.
+        self._setup_to_archive(use_cases.BOOK)
+
+        publisher = u'able'
+        epub_filepath = self.make_epub(use_cases.REVISED_BOOK, publisher,
+                                       u'públishing this book')
+        api_key = self.api_keys_by_uid['no-trust']
+        api_key_headers = [('x-api-key', api_key,)]
+
+        # Moderation is not required, because the publisher is
+        #   vetted by virtue of being added by a another vetted user.
+
+        # Add this publisher to the ACL.
+        with self.db_connect() as db_conn:
+            with db_conn.cursor() as cursor:
+                book = use_cases.REVISED_BOOK
+                ident_hashs = [book.id]
+                ident_hashs.extend(
+                    [d.id for d in cnxepub.flatten_to_documents(book)])
+                from cnxarchive.utils import split_ident_hash
+                for ident_hash in ident_hashs:
+                    id, _ = split_ident_hash(ident_hash)
+                    cursor.execute("""\
+INSERT INTO document_acl (uuid, user_id, permission)
+VALUES (%s, %s, 'publish')""", (id, publisher,))
 
         # 1. --
         resp = self.app_post_publication(epub_filepath,
@@ -1276,7 +1444,9 @@ GROUP BY user_id, accepted
 
         4. Submit an EPUB containing a book of documents.
 
-        5. Verify documents are in the archive. [HACKED]
+        5. Moderate the publication.
+
+        6. Verify documents are in the archive. [HACKED]
 
         """
         publisher = u'ream'
@@ -1357,8 +1527,20 @@ GROUP BY user_id, accepted
         # 4. --
         resp = self.app_post_publication(epub_filepath,
                                          headers=api_key_headers)
-        self.assertEqual(resp.json['state'], 'Done/Success')
+        self.assertEqual(resp.json['state'], 'Waiting for moderation')
         publication_id = resp.json['publication']
+
+        # 5. (manual)
+        # FIXME This needs to be done as a moderator and directly
+        #       calling the route.
+        # Assume moderation acceptance && Manually call poke
+        with self.db_connect() as db_conn:
+            with db_conn.cursor() as cursor:
+                cursor.execute("""\
+UPDATE users SET (is_moderated) = ('t')
+WHERE username = %s""", (publisher,))
+        from ..db import poke_publication_state
+        poke_publication_state(publication_id)
 
         # *. --
         # This is publication completion,
@@ -1366,7 +1548,7 @@ GROUP BY user_id, accepted
         self.app_check_state(publication_id, 'Done/Success',
                              headers=api_key_headers)
 
-        # 5. (manual)
+        # 6. (manual)
         # Checks ``latest_modules`` by virtue of the ``tree_to_json``
         # plsql function.
         binder = use_cases.REVISED_BOOK
@@ -1568,6 +1750,13 @@ WHERE portal_type = 'Collection'""")
                                          headers=api_key_headers)
         self.assertEqual(resp.json['state'], 'Waiting for acceptance')
         publication_id = resp.json['publication']
+
+        # Assume moderation acceptance.
+        with self.db_connect() as db_conn:
+            with db_conn.cursor() as cursor:
+                cursor.execute("""\
+UPDATE users SET (is_moderated) = ('t')
+WHERE username = %s""", (publisher,))
 
         # Post the last accepted licensor.
         for model in (use_cases.REVISED_BOOK, use_cases.REVISED_BOOK[0][0],):

--- a/cnxpublishing/tests/use_cases.py
+++ b/cnxpublishing/tests/use_cases.py
@@ -672,6 +672,32 @@ INSERT INTO document_acl (uuid, user_id, permission)
 VALUES (%s, %s, %s)""", (uuid_, user_id, permission,))
 
 
+def _insert_user_info(model, cursor):
+    """Insert the user shadow table info."""
+    user_ids = set([])
+    for role_attr in cnxepub.ATTRIBUTED_ROLE_KEYS:
+        for role in model.metadata.get(role_attr, []):
+            user_ids.add(role['id'])
+
+    # Check for existing records to update.
+    cursor.execute("SELECT username from users where username = ANY (%s)",
+                   (list(user_ids),))
+    try:
+        existing_user_ids = [x[0] for x in cursor.fetchall()]
+    except TypeError:
+        existing_user_ids = []
+    new_user_ids = [u for u in user_ids if u not in existing_user_ids]
+
+    # At this time, we don't need to store the actual user details.
+    # So, making an entry that contains only a username should be enough.
+
+    # Insert new records.
+    for user_id in new_user_ids:
+        cursor.execute("""\
+INSERT INTO users (username, is_moderated)
+VALUES (%s, 't')""", (user_id,))
+
+
 def setup_BOOK_in_archive(test_case, cursor):
     """Set up BOOK"""
     binder = deepcopy(BOOK)
@@ -688,10 +714,12 @@ def setup_BOOK_in_archive(test_case, cursor):
 
     from ..publish import publish_model
     _insert_control_id(document.id, cursor)
+    _insert_user_info(document, cursor)
     publish_model(cursor, document, publisher, publication_message)
     _set_uri(document)
     _insert_acl_for_model(document, cursor)
     _insert_control_id(binder.id, cursor)
+    _insert_user_info(binder, cursor)
     publish_model(cursor, binder, publisher, publication_message)
     _set_uri(binder)
     _insert_acl_for_model(binder,cursor)
@@ -711,6 +739,7 @@ def setup_PAGE_ONE_in_archive(test_case, cursor):
     from ..publish import publish_model
     if not _is_published(model.ident_hash, cursor):
         _insert_control_id(model.id, cursor)
+        _insert_user_info(model, cursor)
         publish_model(cursor, model, publisher, publication_message)
         _insert_acl_for_model(model, cursor)
     _set_uri(model)
@@ -730,6 +759,7 @@ def setup_PAGE_TWO_in_archive(test_case, cursor):
     from ..publish import publish_model
     if not _is_published(model.ident_hash, cursor):
         _insert_control_id(model.id, cursor)
+        _insert_user_info(model, cursor)
         publish_model(cursor, model, publisher, publication_message)
         _insert_acl_for_model(model, cursor)
     _set_uri(model)
@@ -749,6 +779,7 @@ def setup_PAGE_THREE_in_archive(test_case, cursor):
     from ..publish import publish_model
     if not _is_published(model.ident_hash, cursor):
         _insert_control_id(model.id, cursor)
+        _insert_user_info(model, cursor)
         publish_model(cursor, model, publisher, publication_message)
         _insert_acl_for_model(model, cursor)
     _set_uri(model)
@@ -768,6 +799,7 @@ def setup_PAGE_FOUR_in_archive(test_case, cursor):
     from ..publish import publish_model
     if not _is_published(model.ident_hash, cursor):
         _insert_control_id(model.id, cursor)
+        _insert_user_info(model, cursor)
         publish_model(cursor, model, publisher, publication_message)
         _insert_acl_for_model(model, cursor)
     _set_uri(model)
@@ -796,6 +828,7 @@ def setup_COMPLEX_BOOK_ONE_in_archive(test_case, cursor):
     from ..publish import publish_model
     if not _is_published(model.ident_hash, cursor):
         _insert_control_id(model.id, cursor)
+        _insert_user_info(model, cursor)
         publish_model(cursor, model, publisher, publication_message)
         _insert_acl_for_model(model, cursor)
     _set_uri(model)
@@ -822,6 +855,7 @@ def setup_COMPLEX_BOOK_TWO_in_archive(test_case, cursor):
     from ..publish import publish_model
     if not _is_published(model.ident_hash, cursor):
         _insert_control_id(model.id, cursor)
+        _insert_user_info(model, cursor)
         publish_model(cursor, model, publisher, publication_message)
         _insert_acl_for_model(model, cursor)
     _set_uri(model)
@@ -846,6 +880,7 @@ def setup_COMPLEX_BOOK_THREE_in_archive(test_case, cursor):
     from ..publish import publish_model
     if not _is_published(model.ident_hash, cursor):
         _insert_control_id(model.id, cursor)
+        _insert_user_info(model, cursor)
         publish_model(cursor, model, publisher, publication_message)
         _insert_acl_for_model(model, cursor)
     _set_uri(model)

--- a/cnxpublishing/tests/use_cases.py
+++ b/cnxpublishing/tests/use_cases.py
@@ -143,6 +143,64 @@ REVISED_BOOK[0].metadata['title'] = u"Stifled with Good Inténsions"
 REVISED_BOOK[0].set_title_for_node(REVISED_BOOK[0][0], u"Infinity Plus")
 
 
+SPAM = cnxepub.Binder(
+    id='94f4d0f5@draft',
+    metadata={
+        u'title': u'Eat more spam',
+        u'created': u'2013/03/19 15:01:16 -0500',
+        u'revised': u'2013/03/19 15:01:16 -0500',
+        u'keywords': [],
+        u'language': u'en',
+        u'license_text': u'CC-By 4.0',
+        u'license_url': u'http://creativecommons.org/licenses/by/4.0/',
+        u'subjects': [
+            u'Mathematics and Statistics',
+            u'Science and Technology',
+            ],
+        u'authors': [
+            {u'id': u'happy', u'name': u'Happy Go Lucky',
+             u'type': u'cnx-id'}],
+        u'copyright_holders': [],
+        u'editors': [],
+        u'illustrators': [],
+        u'publishers': [
+            {u'id': u'happy', u'name': u'Happy Go Lucky',
+             u'type': u'cnx-id'}],
+        u'translators': [],
+        u'summary': "<span xmlns='http://www.w3.org/1999/xhtml'>Book summary</span>",
+        u'print_style': None,
+        },
+    nodes=[
+        cnxepub.Document(
+            id=u'2cf4d7d3@draft',
+            data=u'<p class="para">Yummy Yummy SPAM!!!</p>',
+            resources=[],
+            metadata={
+                u'title': u'Eat up!',
+                u'created': u'2013/03/19 15:01:16 -0500',
+                u'revised': u'2013/03/19 15:01:16 -0500',
+                u'keywords': [],
+                u'subjects': [],
+                u'summary': u"<span xmlns='http://www.w3.org/1999/xhtml'>spam</span>",
+                u'language': u'en',
+                u'license_text': u'CC-By 4.0',
+                u'license_url': u'http://creativecommons.org/licenses/by/4.0/',
+                u'authors': [{u'id': u'happy',
+                              u'name': u'Happy Go Lucky',
+                              u'type': u'cnx-id'}],
+                u'copyright_holders': [],
+                u'editors': [],
+                u'illustrators': [],
+                u'publishers': [{u'id': u'happy',
+                                 u'name': u'Happy Go Lucky',
+                                 u'type': u'cnx-id'}],
+                u'translators': [],
+                u'print_style': u'*print style*',
+            },
+        ),
+    ])
+
+
 PAGE_ONE = cnxepub.Document(
     id=u'2cf4d7d3@draft',
     data=u'<p class="para">If you finish the book, there will be cake.</p>',

--- a/cnxpublishing/views.py
+++ b/cnxpublishing/views.py
@@ -524,3 +524,86 @@ def delete_acl_request(request):
     resp = request.response
     resp.status_int = 200
     return resp
+
+
+# ############## #
+#   Moderation   #
+# ############## #
+
+@view_config(route_name='moderation', request_method='GET',
+             accept="application/json",
+             renderer='json')
+def get_moderation(request):
+    """Return the list of publications that need moderation."""
+    settings = request.registry.settings
+
+    with psycopg2.connect(settings[config.CONNECTION_STRING]) as db_conn:
+        with db_conn.cursor() as cursor:
+            cursor.execute("""\
+SELECT row_to_json(combined_rows) FROM (
+  SELECT id, created, publisher, publication_message,
+         (select array_agg(row_to_json(pd))
+          from pending_documents as pd
+          where pd.publication_id = p.id) AS models
+  FROM publications AS p
+  WHERE state = 'Waiting for moderation') AS combined_rows""")
+            moderations = [x[0] for x in cursor.fetchall()]
+
+    return moderations
+
+
+@view_config(route_name='moderate', request_method='POST',
+             accept="application/json")
+def post_moderation(request):
+    settings = request.registry.settings
+    db_conn_str = settings[config.CONNECTION_STRING]
+    publication_id = request.matchdict['id']
+    posted = request.json
+    if 'is_accepted' not in posted \
+       or not isinstance(posted.get('is_accepted'), bool):
+        raise httpexceptions.HTTPBadRequest(
+            "Missing or invalid 'is_accepted' value.")
+    is_accepted = posted['is_accepted']
+
+    with psycopg2.connect(db_conn_str) as db_conn:
+        with db_conn.cursor() as cursor:
+            if is_accepted:
+                # Give the publisher moderation approval.
+                cursor.execute("""\
+UPDATE users SET (is_moderated) = ('t')
+WHERE username = (SELECT publisher FROM publications
+                  WHERE id = %s and state = 'Waiting for moderation')""",
+                               (publication_id,))
+                # Poke the publication into a state change.
+                poke_publication_state(publication_id, cursor)
+            else:
+                # Reject! And Vacuum properties of the publication
+                #   record to /dev/null.
+                cursor.execute("""\
+UPDATE users SET (is_moderated) = ('f')
+WHERE username = (SELECT publisher FROM publications
+                  WHERE id = %sand state = 'Waiting for moderation')""",
+                               (publication_id,))
+                cursor.execute("""\
+UPDATE publications SET (epub, state) = (null, 'Rejected')
+WHERE id = %s""", (publication_id,))
+
+    return httpexceptions.HTTPAccepted()
+
+
+@view_config(route_name='admin-index', request_method='GET',
+             renderer="cnxpublishing:templates/index.html")
+def admin_index(request):  # pragma: no cover
+    return {
+        'navigation': [
+            {'name': 'Moderation List',
+             'uri': request.route_url('admin-moderation'),
+             },
+            ],
+        }
+
+
+@view_config(route_name='admin-moderation', request_method='GET',
+             renderer="cnxpublishing:templates/moderations.html")
+def admin_moderations(request):  # pragma: no cover
+    return {'moderations': get_moderation(request)}

--- a/cnxpublishing/views.py
+++ b/cnxpublishing/views.py
@@ -605,5 +605,7 @@ def admin_index(request):  # pragma: no cover
 
 @view_config(route_name='admin-moderation', request_method='GET',
              renderer="cnxpublishing:templates/moderations.html")
+@view_config(route_name='moderation-rss', request_method='GET',
+             renderer="cnxpublishing:templates/moderations.rss")
 def admin_moderations(request):  # pragma: no cover
     return {'moderations': get_moderation(request)}

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ install_requires = (
     'openstax-accounts>=0.14.0',
     'psycopg2',
     'pyramid>=1.5',
+    'pyramid_jinja2',
     'pyramid_multiauth',
     )
 tests_require = [

--- a/testing.ini
+++ b/testing.ini
@@ -18,6 +18,7 @@ openstax_accounts.stub.users =
   able,able,{"first_name": "Able", "last_name": "Elba", "id": 7, "full_name": "Able Elba", "title": null}
   smoo,smoo,{"first_name": "Smoo", "last_name": "Ooms", "id": 8, "full_name": "Smoo Ooms", "title": null}
   smoopy,smoopy,{"first_name": "Smoopy", "last_name": "Ypooms", "id": 9, "full_name": "Smoopy Ypooms", "title": null}
+  happy, happy,{"first_name": "Happy", "last_name": "Lucky", "id": 10, "full_name": "Happy Go Lucky", "title": null}
 openstax_accounts.stub.message_writer = memory
 openstax_accounts.application_url = http://localhost:8000/
 openstax_accounts.login_path = /login


### PR DESCRIPTION
See also [sprint 37 card](https://trello.com/c/vHW9TWta/1149-create-backend-code-for-pending-queue).

This completes the interface and functionality for accepting/rejecting publications for first time publishers.