### PR TITLE
Add exact match on username for shadow table entry.

### DIFF
--- a/cnxpublishing/db.py
+++ b/cnxpublishing/db.py
@@ -1277,23 +1277,17 @@ def upsert_users(cursor, user_ids):
     accounts = get_current_registry().getUtility(IOpenstaxAccounts)
 
     def lookup_profile(username):
-        user_infos = accounts.global_search('username:{}'.format(username))
+        profile = accounts.get_profile_by_username(username)
         # See structure documentation at:
         #   https://<accounts-instance>/api/docs/v1/users/index
-        user_info = None
-        for item in user_infos['items']:
-            if item['username'] == username:
-                # Ensure an exact match.
-                user_info = item
-                break
-        if user_info is None:
+        if profile is None:
             raise UserFetchError(username)
 
         opt_attrs = ('first_name', 'last_name', 'full_name',
                      'title', 'suffix',)
         for attr in opt_attrs:
-            user_info.setdefault(attr, None)
-        return user_info
+            profile.setdefault(attr, None)
+        return profile
 
     _upsert_users(cursor, user_ids, lookup_profile)
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ install_requires = (
     'cnx-archive',
     'cnx-epub',
     'jinja2',
-    'openstax-accounts>=0.14.0',
+    'openstax-accounts>=1.0.0',
     'psycopg2',
     'pyramid>=1.5',
     'pyramid_jinja2',


### PR DESCRIPTION
Uses the exact match username api. See also openstax/accounts#134.

Depends on Connexions/openstax-accounts#20.