### PR TITLE
Fix duplicate resource insertion

### DIFF
--- a/cnxpublishing/tests/testing.py
+++ b/cnxpublishing/tests/testing.py
@@ -12,11 +12,15 @@ import psycopg2
 from pyramid.paster import get_appsettings
 
 
-__all__ = ('integration_test_settings', 'db_connection_factory', 'db_connect',)
+__all__ = (
+    'TEST_DATA_DIR'
+    'integration_test_settings',
+    'db_connection_factory', 'db_connect',
+    )
 
 
 here = os.path.abspath(os.path.dirname(__file__))
-
+TEST_DATA_DIR = os.path.join(here, 'data')
 
 def integration_test_settings():
     """Integration settings initializer"""


### PR DESCRIPTION
This now checks for the existence of the same module_files entry
before attempting to insert another. A forwards compatible exception
has been put in to catch actual filename conflicts, which at this
time should be impossible.

Closes #94