### PR TITLE
Add YAML logging configuration

### DIFF
--- a/development.ini
+++ b/development.ini
@@ -12,6 +12,10 @@ pyramid.debug_notfound = false
 pyramid.debug_routematch = false
 pyramid.default_locale_name = en
 pyramid.includes =
+    pyramid_sawing
+
+pyramid_sawing.file = %(here)s/logging.yaml
+pyramid_sawing.transit_logging.enabled? = yes
 
 db-connection-string = dbname=cnxarchive user=cnxarchive password=cnxarchive
 # size limit of file uploads in MB
@@ -57,35 +61,3 @@ openstax_accounts.logout_redirects_to = /a/
 use = egg:waitress#main
 host = 0.0.0.0
 port = 6543
-
-###
-# logging configuration
-# http://docs.pylonsproject.org/projects/pyramid/en/latest/narr/logging.html
-###
-
-[loggers]
-keys = root, cnxpublishing
-
-[handlers]
-keys = console
-
-[formatters]
-keys = generic
-
-[logger_root]
-level = DEBUG
-handlers = console
-
-[logger_cnxpublishing]
-level = DEBUG
-handlers =
-qualname = cnxpublishing
-
-[handler_console]
-class = StreamHandler
-args = (sys.stderr,)
-level = NOTSET
-formatter = generic
-
-[formatter_generic]
-format = %(asctime)s %(levelname)-5.5s [%(name)s][%(threadName)s] %(message)s

--- a/logging.yaml
+++ b/logging.yaml
@@ -1,0 +1,62 @@
+###
+# logging configuration
+###
+version: 1
+
+formatters:
+  generic:
+    format    : '%(asctime)s %(levelname)-5.5s [%(name)s][%(threadName)s] %(message)s'
+  papertrail:
+    # requires filters [context]
+    format    : '%(asctime)s %(hostname)s publishing %(message)s'
+    datefmt   : '%Y-%m-%dT%H:%M:%S'
+  apache_style:
+    # requires filters [environ]
+    format    : '%(REMOTE_ADDR)s - %(REMOTE_USER)s [%(asctime)s] "%(REQUEST_METHOD)s %(REQUEST_URI)s %(HTTP_VERSION)s" %(status)s %(bytes)s "%(HTTP_REFERER)s" "%(HTTP_USER_AGENT)s"'
+    datefmt   : '%d/%b/%Y:%H:%M:%S'
+filters:
+  context:
+    ()        : pyramid_sawing.filters.ContextFilter
+  environ:
+    ()        : pyramid_sawing.filters.EnvironFilter
+handlers:
+  console:
+    class     : logging.StreamHandler
+    level     : NOTSET
+    formatter : generic
+    stream    : 'ext://sys.stdout'
+  # syslog:
+  #   # Streams directly to papertrailapp.com.
+  #   # You'll need to change the host and port in order to use this.
+  #   class     : logging.handlers.SysLogHandler
+  #   level     : DEBUG
+  #   formatter : papertrail
+  #   # Note, the environ filter is automatically included by pyramid_sawing.
+  #   filters   : [context, environ]
+  #   address   : ['<host>.papertrailapp.com', 11111]
+  transit:
+    # Streams to standard out (STDOUT) using the apache-style formatter.
+    class     : logging.StreamHandler
+    level     : NOTSET
+    formatter : apache_style
+    stream    : 'ext://sys.stdout'
+loggers:
+  cnxpublishing:
+    # This is our pyramid application logger.
+    level     : DEBUG
+    handlers  : [console]
+    propagate : 0
+  transit_logger:
+    # This is the transit logger in pyramid_sawing.
+    level     : INFO
+    handlers  : [transit]
+    propagate : 0
+  waitress:
+    # The logger for the waitress http server.
+    # Note, that this logger is responsible for reporting 500 errors
+    # with the traceback.
+    level     : DEBUG
+    propagate : 1
+root:
+  level       : NOTSET
+  handlers    : [console]


### PR DESCRIPTION
Addresses [Unified Logging](https://trello.com/c/re87Xkf5/1187-unified-logging).

This changes the logging configuration to YAML, which will enable us to configure logging filters.

I did not add pyramid_sawing to the ``setup.py`` since it is an configuration included package. In other  words, cnx-authoring does not required it to function as usual.