### PR TITLE
Pin mock==1.0.1 for tests in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ description = """\
 Application for accepting publication requests to the Connexions Archive."""
 
 if not IS_PY3:
-    tests_require.append('mock')
+    tests_require.append('mock==1.0.1')
 
 setup(
     name='cnx-publishing',


### PR DESCRIPTION
mock >= 1.1.0 requires setuptools >= 17.1.

(The requirement was added in 1.1.3, but 1.1.0 is the first version that
stopped working)