### PR TITLE
Update split_ident_hash to catch missing version and short id exceptions

### DIFF
--- a/cnxpublishing/db.py
+++ b/cnxpublishing/db.py
@@ -16,10 +16,7 @@ import uuid
 import cnxepub
 import psycopg2
 import jinja2
-from cnxarchive.utils import (
-    IdentHashSyntaxError,
-    join_ident_hash, split_ident_hash,
-    )
+from cnxarchive.utils import IdentHashSyntaxError, IdentHashShortId
 from cnxepub import ATTRIBUTED_ROLE_KEYS
 from openstax_accounts.interfaces import IOpenstaxAccounts
 from psycopg2.extras import register_uuid
@@ -35,7 +32,8 @@ from .exceptions import (
     ResourceFileExceededLimitError,
     UserFetchError,
     )
-from .utils import parse_archive_uri, parse_user_uri
+from .utils import (parse_archive_uri, parse_user_uri, join_ident_hash,
+                    split_ident_hash)
 from .publish import publish_model, republish_binders
 
 
@@ -327,7 +325,7 @@ def _validate_derived_from(cursor, model):
     try:
         ident_hash = parse_archive_uri(derived_from_uri)
         uuid_, version = split_ident_hash(ident_hash, split_version=True)
-    except (ValueError, IdentHashSyntaxError) as exc:
+    except (ValueError, IdentHashSyntaxError, IdentHashShortId) as exc:
         raise exceptions.InvalidMetadata('derived_from_uri', derived_from_uri,
                                          original_exception=exc)
     # Is the ident-hash a valid pointer?

--- a/cnxpublishing/publish.py
+++ b/cnxpublishing/publish.py
@@ -11,9 +11,8 @@ Functions used to commit publication works to the archive.
 import cnxepub
 import psycopg2
 from cnxepub import Document, Binder
-from cnxarchive.utils import join_ident_hash, split_ident_hash
 
-from .utils import parse_user_uri
+from .utils import parse_user_uri, join_ident_hash, split_ident_hash
 
 
 __all__ = ('publish_model',)

--- a/cnxpublishing/tests/test_db.py
+++ b/cnxpublishing/tests/test_db.py
@@ -21,9 +21,9 @@ import psycopg2
 import cnxepub
 from cnxarchive import config as archive_config
 from cnxarchive.database import initdb as archive_initdb
-from cnxarchive.utils import join_ident_hash, split_ident_hash
 from pyramid import testing
 
+from ..utils import join_ident_hash, split_ident_hash
 from . import use_cases
 from .testing import db_connect, integration_test_settings
 

--- a/cnxpublishing/tests/test_views.py
+++ b/cnxpublishing/tests/test_views.py
@@ -19,7 +19,6 @@ import psycopg2
 import cnxepub
 from cnxarchive import config as archive_config
 from cnxarchive.database import initdb as archive_initdb
-from cnxarchive.utils import join_ident_hash
 from webob import Request
 from webtest import TestApp
 from webtest import AppError
@@ -27,6 +26,7 @@ from webtest.forms import Upload
 from pyramid import testing
 from pyramid import httpexceptions
 
+from ..utils import join_ident_hash, split_ident_hash
 from . import use_cases
 from .testing import (
     integration_test_settings,
@@ -1305,7 +1305,6 @@ GROUP BY user_id, accepted
                 ident_hashs = [book.id]
                 ident_hashs.extend(
                     [d.id for d in cnxepub.flatten_to_documents(book)])
-                from cnxarchive.utils import split_ident_hash
                 for ident_hash in ident_hashs:
                     id, _ = split_ident_hash(ident_hash)
                     cursor.execute("""\
@@ -1560,7 +1559,6 @@ GROUP BY user_id, accepted
         api_key_headers = [('x-api-key', api_key,)]
 
         # 1. --
-        from cnxarchive.utils import split_ident_hash
         ids = [
             split_ident_hash(use_cases.REVISED_BOOK.id)[0],
             split_ident_hash(use_cases.REVISED_BOOK[0][0].id)[0],
@@ -1812,7 +1810,6 @@ WHERE portal_type = 'Collection'""")
         api_key_headers = [('x-api-key', api_key,)]
 
         # Give publisher permission to publish
-        from cnxarchive.utils import split_ident_hash
         ids = [
             split_ident_hash(use_cases.REVISED_BOOK.id)[0],
             split_ident_hash(use_cases.REVISED_BOOK[0][0].id)[0],

--- a/cnxpublishing/tests/use_cases.py
+++ b/cnxpublishing/tests/use_cases.py
@@ -12,7 +12,8 @@ import json
 from copy import deepcopy
 
 import cnxepub
-from cnxarchive.utils import join_ident_hash, split_ident_hash
+
+from ..utils import join_ident_hash, split_ident_hash
 
 
 here = os.path.abspath(os.path.dirname(__file__))

--- a/cnxpublishing/utils.py
+++ b/cnxpublishing/utils.py
@@ -14,8 +14,11 @@ try:
 except ImportError:
     from urllib2 import unquote
 
+import cnxarchive.utils
+
 
 __all__ = (
+    'join_ident_hash', 'split_ident_hash',
     'parse_archive_uri', 'parse_user_uri',
     )
 
@@ -37,3 +40,16 @@ def parse_user_uri(uri, type_='cnx-id'):
     # We have added a unique UUID for each user; and that is what
     # we will use in epub import/export for now.
     return uri
+
+
+def split_ident_hash(*args, **kwargs):
+    try:
+        return cnxarchive.utils.split_ident_hash(*args, **kwargs)
+    except cnxarchive.utils.IdentHashMissingVersion as e:
+        version = None
+        if kwargs.get('split_version'):
+            version = (None, None)
+        return e.id, version
+
+
+join_ident_hash = cnxarchive.utils.join_ident_hash


### PR DESCRIPTION
See `split_ident_hash` changes in https://github.com/Connexions/cnx-archive/pull/397