### PR TITLE
Puts API keys in the database

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -167,7 +167,7 @@ variables::
     >>> import cnxepub
 
     # As configured in development.ini
-    >>> api_key = 'developer'
+    >>> api_key = 'dev'
     >>> base_url = 'http://localhost:6543'
 
 Publishing content
@@ -197,7 +197,7 @@ The following is an example publication using some pre-build content::
     ...               'application/octet-stream',),)]
     >>> headers = {'x-api-key': api_key}
     >>> resp = requests.post(url, files=file_payload, headers=headers)
-    >>> assert resp.status_code == 200
+    >>> assert resp.status_code == 200, resp.status_code
 
     # The info returned from a successful POST looks something like this.
     >>> pprint(resp.json())

--- a/cnxpublishing/authnz.py
+++ b/cnxpublishing/authnz.py
@@ -12,22 +12,34 @@ from zope.interface import implementer
 from pyramid.interfaces import IAuthenticationPolicy
 from pyramid import security
 
+from cnxpublishing.db import with_db_cursor
+
+
+ALL_KEY_INFO_SQL_STMT = "SELECT id, key, name, groups FROM api_keys"
+
+
+def lookup_api_key_info(cursor):
+    """Given a dbapi cursor, lookup all the api keys and their information."""
+    info = {}
+    cursor.execute(ALL_KEY_INFO_SQL_STMT)
+    for row in cursor.fetchall():
+        id, key, name, groups = row
+        user_id = "api_key:{}".format(id)
+        info[key] = dict(id=id, user_id=user_id, name=name, groups=groups)
+    return info
+
 
 @implementer(IAuthenticationPolicy)
 class APIKeyAuthenticationPolicy(object):
     """Authentication using preconfigured API keys"""
 
-    def __init__(self, entities=None):
-        """The ``entities`` value is a three value
-        tuple containing the api-key, user-id and list of groups.
-        """
-        self._api_key_index = {}
-        self._principals = []  # (<uid>, [<group>, ...],)
-        entities = entities or []
-        for i, entity in enumerate(entities):
-            key = entity[0]
-            self._principals.insert(i, entity[1:])
-            self._api_key_index[key] = i
+    @with_db_cursor
+    def _lookup_api_key_info(self, cursor):
+        return lookup_api_key_info(cursor)
+
+    @property
+    def user_info_by_key(self):
+        return self._lookup_api_key_info()
 
     def _discover_requesting_party(self, request):
         """With the request object, discover who is making the request.
@@ -36,15 +48,16 @@ class APIKeyAuthenticationPolicy(object):
         user_id = None
         api_key = request.headers.get('x-api-key', None)
         try:
-            principal_index = self._api_key_index[api_key]
+            principal_info = self.user_info_by_key[api_key]
         except KeyError:
-            principal_index = None
-        if principal_index is not None:
-            user_id = self._principals[principal_index][0]
-        return api_key, user_id
+            principal_info = None
+        if principal_info is not None:
+            user_id = principal_info['user_id']
+        return api_key, user_id, principal_info
 
     def authenticated_userid(self, request):
-        api_key, user_id = self._discover_requesting_party(request)
+        api_key, user_id, _ = self._discover_requesting_party(request)
+        return user_id
 
     # We aren't using a persistent store, for these,
     # so the implementation can be the same.
@@ -55,10 +68,13 @@ class APIKeyAuthenticationPolicy(object):
         including the userid and any groups belonged to by the current
         user, including 'system' groups such as Everyone and
         Authenticated. """
-        api_key, user_id = self._discover_requesting_party(request)
+        api_key, user_id, info = self._discover_requesting_party(request)
         if api_key is None or user_id is None:
             return []
-        principals = list(self._principals[self._api_key_index[api_key]])
+        try:
+            principals = list(info['groups'])
+        except TypeError:
+            principals = []
         principals.append(security.Everyone)
         principals.append(security.Authenticated)
         return principals

--- a/cnxpublishing/authnz.py
+++ b/cnxpublishing/authnz.py
@@ -13,11 +13,13 @@ from pyramid.interfaces import IAuthenticationPolicy
 from pyramid import security
 
 from cnxpublishing.db import db_connect
+from cnxpublishing.main import cache
 
 
 ALL_KEY_INFO_SQL_STMT = "SELECT id, key, name, groups FROM api_keys"
 
 
+@cache.cache(expire=60*60*24)  # cache for one day
 def lookup_api_key_info():
     """Given a dbapi cursor, lookup all the api keys and their information."""
     info = {}

--- a/cnxpublishing/db.py
+++ b/cnxpublishing/db.py
@@ -38,6 +38,7 @@ from .publish import publish_model, republish_binders
 
 
 __all__ = (
+    'db_connect',
     'initdb',
     'add_publication',
     'poke_publication_state', 'check_publication_state',
@@ -61,9 +62,16 @@ END_N_INTERIM_STATES = ('Publishing', 'Done/Success',
 register_uuid()
 
 
+def db_connect(connection_string=None):
+    """Function to supply a database connection object."""
+    if connection_string is None:
+        connection_string = get_current_registry().settings[CONNECTION_STRING]
+    return psycopg2.connect(connection_string)
+
+
 def initdb(connection_string):
     """Initialize publishing in or along-side the archive database."""
-    with psycopg2.connect(connection_string) as db_conn:
+    with db_connect(connection_string) as db_conn:
         with db_conn.cursor() as cursor:
             for filename in SCHEMA_FILES:
                 schema_filepath = os.path.join(SQL_DIR, filename)

--- a/cnxpublishing/main.py
+++ b/cnxpublishing/main.py
@@ -61,6 +61,10 @@ def declare_api_routes(config):
     add_route('moderate', '/moderations/{id}')
     add_route('moderation-rss', '/feeds/moderations.rss')
 
+    # API Key routes
+    add_route('api-keys', '/api-keys')
+    add_route('api-key', '/api-keys/{id}')
+
 
 def declare_browsable_routes(config):
     """Declaration of routes that can be browsed by users."""
@@ -71,6 +75,7 @@ def declare_browsable_routes(config):
     add_route = config.add_route
     add_route('admin-index', '/a/')
     add_route('admin-moderation', '/a/moderation/')
+    add_route('admin-api-keys', '/a/api-keys/')
 
 
 def declare_routes(config):
@@ -147,7 +152,10 @@ class RootFactory(object):
           )),
         (security.Allow, 'g:reviewers', ('preview',)),
         (security.Allow, 'g:moderators', ('preview', 'moderate',)),
-        (security.Allow, 'g:administrators', ('preview', 'moderate',)),
+        (security.Allow, 'g:administrators',
+         ('preview',
+          'moderate',
+          'administer')),
         security.DENY_ALL,
         )
 

--- a/cnxpublishing/main.py
+++ b/cnxpublishing/main.py
@@ -17,8 +17,6 @@ from pyramid.httpexceptions import default_exceptionresponse_view
 from pyramid.session import SignedCookieSessionFactory
 from pyramid_multiauth import MultiAuthenticationPolicy
 
-from .authnz import APIKeyAuthenticationPolicy
-
 
 __version__ = '0.1'
 __name__ = 'cnxpublishing'
@@ -95,6 +93,7 @@ def main(global_config, **settings):
         settings.get('session_key', 'itsaseekreet'))
     config.set_session_factory(session_factory)
 
+    from .authnz import APIKeyAuthenticationPolicy
     api_key_authn_policy = APIKeyAuthenticationPolicy()
     config.include('openstax_accounts')
     openstax_authn_policy = config.registry.getUtility(

--- a/cnxpublishing/main.py
+++ b/cnxpublishing/main.py
@@ -5,6 +5,7 @@
 # Public License version 3 (AGPLv3).
 # See LICENCE.txt for details.
 # ###
+import os
 import tempfile
 
 from cnxarchive.utils import join_ident_hash
@@ -21,6 +22,14 @@ from .authnz import APIKeyAuthenticationPolicy
 
 __version__ = '0.1'
 __name__ = 'cnxpublishing'
+
+
+def find_migrations_directory():  # pragma: no cover
+    """Finds and returns the location of the database migrations directory.
+    This function is used from a setuptools entry-point for db-migrator.
+    """
+    here = os.path.abspath(os.path.dirname(__file__))
+    return os.path.join(here, 'sql/migrations')
 
 
 def declare_api_routes(config):

--- a/cnxpublishing/main.py
+++ b/cnxpublishing/main.py
@@ -77,17 +77,6 @@ def declare_routes(config):
     declare_browsable_routes(config)
 
 
-def _parse_api_key_lines(settings):
-    """Parse the api-key lines from the settings."""
-    api_key_entities = []
-    for line in settings['api-key-authnz'].split('\n'):
-        if not line.strip():
-            continue
-        entity = [x.strip() for x in line.split(',') if x.strip()]
-        api_key_entities.append(entity)
-    return api_key_entities
-
-
 def main(global_config, **settings):
     """Application factory"""
     config = Configurator(settings=settings, root_factory=RootFactory)
@@ -97,8 +86,7 @@ def main(global_config, **settings):
         settings.get('session_key', 'itsaseekreet'))
     config.set_session_factory(session_factory)
 
-    api_key_entities = _parse_api_key_lines(settings)
-    api_key_authn_policy = APIKeyAuthenticationPolicy(api_key_entities)
+    api_key_authn_policy = APIKeyAuthenticationPolicy()
     config.include('openstax_accounts')
     openstax_authn_policy = config.registry.getUtility(
         IOpenstaxAccountsAuthenticationPolicy)

--- a/cnxpublishing/main.py
+++ b/cnxpublishing/main.py
@@ -8,6 +8,8 @@
 import os
 import tempfile
 
+from beaker.cache import CacheManager
+from beaker.util import parse_cache_config_options
 from cnxarchive.utils import join_ident_hash
 from openstax_accounts.interfaces import IOpenstaxAccountsAuthenticationPolicy
 from pyramid.config import Configurator
@@ -20,6 +22,11 @@ from pyramid_multiauth import MultiAuthenticationPolicy
 
 __version__ = '0.1'
 __name__ = 'cnxpublishing'
+
+
+# Provides a means of caching function results.
+# (This is reassigned with configuration in ``main()``.)
+cache = CacheManager()
 
 
 def find_migrations_directory():  # pragma: no cover
@@ -92,6 +99,9 @@ def main(global_config, **settings):
     session_factory = SignedCookieSessionFactory(
         settings.get('session_key', 'itsaseekreet'))
     config.set_session_factory(session_factory)
+
+    global cache
+    cache = CacheManager(**parse_cache_config_options(settings))
 
     from .authnz import APIKeyAuthenticationPolicy
     api_key_authn_policy = APIKeyAuthenticationPolicy()

--- a/cnxpublishing/sql/migrations/20160104115058_add_api_keys_table.py
+++ b/cnxpublishing/sql/migrations/20160104115058_add_api_keys_table.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+
+
+def up(cursor):
+    cursor.execute("""\
+CREATE TABLE api_keys (
+  "id" SERIAL PRIMARY KEY,
+  -- Any text that the service will use as an api key.
+  "key" TEXT NOT NULL,
+  -- This is a human readable name of the person, organization or service
+  -- that we are giving an api key.
+  "name" TEXT NOT NULL,
+  -- A list of groups that this api key is a member of.
+  -- For example, g:publishers or g:trusted-publishers.
+  -- See the documenation about available groups.
+  "groups" TEXT[]
+);
+""")
+
+
+def down(cursor):
+    cursor.execute("DROP TABLE api_keys;")

--- a/cnxpublishing/sql/schema-tables.sql
+++ b/cnxpublishing/sql/schema-tables.sql
@@ -85,3 +85,17 @@ CREATE TABLE role_acceptances (
   PRIMARY KEY ("uuid", "user_id", "role_type"),
   FOREIGN KEY ("uuid") REFERENCES document_controls ("uuid")
 );
+
+
+CREATE TABLE api_keys (
+  "id" SERIAL PRIMARY KEY,
+  -- Any text that the service will use as an api key.
+  "key" TEXT NOT NULL,
+  -- This is a human readable name of the person, organization or service
+  -- that we are giving an api key.
+  "name" TEXT NOT NULL,
+  -- A list of groups that this api key is a member of.
+  -- For example, g:publishers or g:trusted-publishers.
+  -- See the documenation about available groups.
+  "groups" TEXT[]
+);

--- a/cnxpublishing/templates/api-keys.html
+++ b/cnxpublishing/templates/api-keys.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+{% block content %}
+  <h1>API Keys</h1>
+  <table>
+    <tr>
+      <th>Key</th>
+      <th>Name</th>
+      <th>Groups</th>
+    </tr>
+    {% for info in api_keys %}
+      <tr id="{{ info.id ~ '-row' }}">
+        <td>{{ info.key }}</td>
+        <td>{{ info.name }}</td>
+        <td>{{ ', '.join(info.groups) }}</td>
+      </tr>
+    {% endfor %}
+  </table>
+{% endblock %}

--- a/cnxpublishing/tests/test_db.py
+++ b/cnxpublishing/tests/test_db.py
@@ -38,6 +38,23 @@ else:
     STDERR_MOCK_CLASS = StringIO
 
 
+class DatabaseUtilsTestCase(unittest.TestCase):
+    """Verify the database utility functions are working as expected"""
+
+    def test_db_connect(self):
+        from ..db import db_connect
+
+        settings = integration_test_settings()
+        from ..config import CONNECTION_STRING
+        db_conn_str = settings[CONNECTION_STRING]
+
+        with db_connect(db_conn_str) as conn:
+            with conn.cursor() as cur:
+                cur.execute("select true")
+                result = cur.fetchone()[0]
+        self.assertTrue(result)
+
+
 class BaseDatabaseIntegrationTestCase(unittest.TestCase):
     """Verify database interactions"""
 

--- a/cnxpublishing/tests/test_views.py
+++ b/cnxpublishing/tests/test_views.py
@@ -118,7 +118,7 @@ class BaseFunctionalViewTestCase(unittest.TestCase, EPUBMixInTestCase):
             from ..authnz import lookup_api_key_info
             with self.db_connect() as db_conn:
                 with db_conn.cursor() as cursor:
-                    return lookup_api_key_info(cursor)
+                    return lookup_api_key_info()
 
         if api_keys is None:
             self.addCleanup(delattr, self, attr_name)
@@ -147,6 +147,12 @@ class BaseFunctionalViewTestCase(unittest.TestCase, EPUBMixInTestCase):
             with db_conn.cursor() as cursor:
                 cursor.executemany("INSERT INTO api_keys (key, name, groups) "
                                    "VALUES (%s, %s, %s)", key_info)
+        self.addCleanup(self.tear_down_api_keys)
+
+    def tear_down_api_keys(self):
+        # Invalidate the api_key lookup cache
+        from cnxpublishing import authnz
+        authnz.cache.invalidate(authnz.lookup_api_key_info)
 
     @classmethod
     def setUpClass(cls):

--- a/cnxpublishing/tests/test_views.py
+++ b/cnxpublishing/tests/test_views.py
@@ -62,6 +62,63 @@ class PublishViewsTestCase(unittest.TestCase):
         self.assertEqual(exc.args, ('Format not recognized.',))
 
 
+class ApiKeyViewsTestCase(unittest.TestCase):
+    # This ignores testing the security policy. The views are directly
+    # protected by permissions. If at some point a view starts checking
+    # for particular permissions inside the view, then you should test
+    # for that case.
+
+    @classmethod
+    def setUpClass(cls):
+        cls.settings = integration_test_settings()
+        from ..config import CONNECTION_STRING
+        cls.db_conn_str = cls.settings[CONNECTION_STRING]
+        cls.db_connect = staticmethod(db_connection_factory())
+
+    def setUp(self):
+        self.config = testing.setUp(settings=self.settings)
+        archive_settings = {
+            archive_config.CONNECTION_STRING: self.db_conn_str,
+            }
+        archive_initdb(archive_settings)
+        from ..db import initdb
+        initdb(self.db_conn_str)
+
+    def tearDown(self):
+        with self.db_connect() as db_conn:
+            with db_conn.cursor() as cursor:
+                cursor.execute("DROP SCHEMA public CASCADE")
+                cursor.execute("CREATE SCHEMA public")
+        testing.tearDown()
+
+    def test_get(self):
+        request = testing.DummyRequest()
+
+        # Insert some keys to list in the view.
+        api_keys = [
+            ['abc', "ABC", ['g:publishers']],
+            ['xyz', "XYZ", ['g:trusted-publishers']],
+            ]
+        insert_stmt = "INSERT INTO api_keys (key, name, groups) " \
+                      "VALUES (%s, %s, %s)" \
+                      "RETURNING id, key, name, groups"
+        expected_api_keys = []
+        with self.db_connect() as db_conn:
+            with db_conn.cursor() as cursor:
+                for values in api_keys:
+                    cursor.execute(insert_stmt, values)
+                    row = cursor.fetchone()
+                    expected_api_keys.append(row)
+        _keys = ['id', 'key', 'name', 'groups']
+        expected_api_keys = [dict(zip(_keys, x)) for x in expected_api_keys]
+
+        # Call the target...
+        from ..views import get_api_keys
+        resp_data = get_api_keys(request)
+
+        self.assertEqual(resp_data, expected_api_keys)
+
+
 class EPUBMixInTestCase(object):
 
     def setUp(self):

--- a/cnxpublishing/tests/testing.ini
+++ b/cnxpublishing/tests/testing.ini
@@ -1,10 +1,6 @@
 [app:main]
 use = egg:cnx-publishing
 db-connection-string = dbname=cnxarchive-testing user=cnxarchive password=cnxarchive host=localhost port=5432
-api-key-authnz =
-  4e8,no-trust,
-  b07,some-trust,g:trusted-publishers
-  developer,g:trusted-publishers
 # size limit of file uploads in MB
 file-upload-limit = 1
 openstax_accounts.stub = true

--- a/development.ini
+++ b/development.ini
@@ -22,13 +22,7 @@ db-connection-string = dbname=cnxarchive user=cnxarchive password=cnxarchive
 file-upload-limit = 50
 
 session_key = 'somkindaseekret'
-# Application API keys with authentication information.
-# This information is organized in the following form:
-#   <api-key>,<name>,<trust-level=(FULL_TRUST)>|<null>
-api-key-authnz =
-  b07,g:trusted-publishers
-  developer,g:publishers
-  4e8,loading-zone,
+
 openstax_accounts.stub = true
 openstax_accounts.stub.message_writer = log
 openstax_accounts.stub.users =

--- a/setup.py
+++ b/setup.py
@@ -50,5 +50,7 @@ setup(
     main = cnxpublishing.main:main
     [console_scripts]
     cnx-publishing-initdb = cnxpublishing.scripts.initdb:main
+    [dbmigrator]
+    migrations_directory = cnxpublishing.main:find_migrations_directory
     """,
     )

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ from setuptools import setup, find_packages
 IS_PY3 = sys.version_info > (3,)
 
 install_requires = (
+    'beaker',
     'cnx-archive',
     'cnx-epub',
     'jinja2',


### PR DESCRIPTION
This adds [Beaker](https://beaker.readthedocs.org/en/latest/) as a dependency for caching the results of a function. It's only usage at this time is hardcoded to cache for 24 hours. Later we can add a means of invalidation to our admin interface, but for now one day shouldn't be a problem, especially since no one else is using publishing.

The thing to test here is the db-migrator step. One, does the migration directory get found? And two, can you apply the migration and roll it back?