### PR TITLE
Make sure unittest fails if doctest has failures

### DIFF
--- a/cnxpublishing/tests/test_doctests.py
+++ b/cnxpublishing/tests/test_doctests.py
@@ -51,6 +51,9 @@ UPDATE document_controls AS dc
 SET licenseid = l.licenseid FROM licenses AS l WHERE url = %s and is_valid_for_publication = 't'
 RETURNING dc.licenseid""", ('http://creativecommons.org/licenses/by/4.0/',))
 
-        doctest.testfile(
+        results = doctest.testfile(
             '../../README.rst',
             optionflags=doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE)
+
+        if results.failed:
+            self.fail('DocTest failed: {}'.format(results))


### PR DESCRIPTION
Even if README examples failed, unittest was passing:

```
**********************************************************************
1 items had failures:
  29 of  62 in README.rst
***Test Failed*** 29 failures.
ok

----------------------------------------------------------------------
Ran 1 test in 6.217s

OK
```

This PR changes this to:

```
**********************************************************************
1 items had failures:
  29 of  62 in README.rst
***Test Failed*** 29 failures.
FAIL

======================================================================
FAIL: test_readme (cnxpublishing.tests.test_doctests.DocTestTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/karen/cnx-publishing/cnxpublishing/tests/test_doctests.py", line 59, in test_readme
    self.fail('DocTest failed: {}'.format(results))
AssertionError: DocTest failed: TestResults(failed=29, attempted=62)

----------------------------------------------------------------------
Ran 1 test in 6.221s

FAILED (failures=1)
```