### PR TITLE
Add the database host and port to the testing configuration

### DIFF
--- a/cnxpublishing/tests/testing.ini
+++ b/cnxpublishing/tests/testing.ini
@@ -1,6 +1,6 @@
 [app:main]
 use = egg:cnx-publishing
-db-connection-string = dbname=cnxarchive-testing user=cnxarchive password=cnxarchive
+db-connection-string = dbname=cnxarchive-testing user=cnxarchive password=cnxarchive host=localhost port=5432
 api-key-authnz =
   4e8,no-trust,
   b07,some-trust,g:trusted-publishers


### PR DESCRIPTION
This makes the config line consistent with the cnx-archive
testing configuration.