### PR TITLE
Address the move from module_files.mimetype to files.media_type

### DIFF
--- a/cnxpublishing/tests/use_cases.py
+++ b/cnxpublishing/tests/use_cases.py
@@ -605,7 +605,7 @@ WHERE portal_type = 'Collection'""")
                            _read_file(RESOURCE_ONE_FILEPATH).read()) \
                       .hexdigest()
     cursor.execute("""\
-SELECT f.file, mf.mimetype,
+SELECT f.file, f.media_type,
        m.uuid||'@'||concat_ws('.',m.major_version,m.minor_version)
 FROM files as f natural join module_files as mf, latest_modules as m
 WHERE
@@ -688,7 +688,7 @@ WHERE portal_type = 'Collection'""")
                            _read_file(RESOURCE_ONE_FILEPATH).read()) \
                       .hexdigest()
     cursor.execute("""\
-SELECT f.file, mf.mimetype,
+SELECT f.file, f.media_type,
        m.uuid||'@'||concat_ws('.',m.major_version,m.minor_version)
 FROM files as f natural join module_files as mf, latest_modules as m
 WHERE


### PR DESCRIPTION
This change was created to respond to the changes found in Connexions/cnx-archive#403.

Drop the last commit prefixed :skull: **before you merge**. It was created to make sure travis tests pass against the related branch in cnx-archive.