### PR TITLE
Add route to invoke the cooking process for a book

### DIFF
--- a/cnxpublishing/main.py
+++ b/cnxpublishing/main.py
@@ -55,6 +55,7 @@ def declare_api_routes(config):
               '/publications/{id}/license-acceptances/{uid}')
     add_route('publication-role-acceptance',
               '/publications/{id}/role-acceptances/{uid}')
+    add_route('cook-content', '/contents/{ident_hash}/cook-content')
 
     # Moderation routes
     add_route('moderation', '/moderations')


### PR DESCRIPTION
This PR is based on the `collate` branch and it depends on the `collate` branches on `cnx-archive` and `cnx-epub`.