### PR TITLE
Fix republishing of binders with trees latest flag set to null

### DIFF
--- a/cnxpublishing/publish.py
+++ b/cnxpublishing/publish.py
@@ -676,7 +676,7 @@ RETURNING nodeid"""
         data = tree[nodeid]
         data['parent_id'] = parent_id
         if history_map.get(data['ident_hash']) is not None \
-           and data['latest']:
+           and (data['latest'] or parent_id is None):
             data['ident_hash'] = history_map[data['ident_hash']]
         new_nodeid = insert(data)
         for child_nodeid in children.get(nodeid, []):


### PR DESCRIPTION
Binders published using cnx-publishing (at the time of writing) always
have trees latest flag set to true, but there are lots of binders in the
database with trees latest flag set to null.  The code for republishing
a binder doesn't use the new module_ident / documentid when inserting
into the trees table, causing this error.

```
======================================================================
ERROR: test_republish_binder_tree_not_latest (cnxpublishing.tests.test_publish.RepublishTestCase)
Verify republishing of binders that has trees with latest flag set
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/karen/cnx-publishing/cnxpublishing/tests/testing.py", line 66, in wrapped
    return method(self, cursor, *args, **kwargs)
  File "/home/karen/cnx-publishing/cnxpublishing/tests/test_publish.py", line 612, in test_republish_binder_tree_not_latest
    self.call_target(cursor, [page_one])
  File "/home/karen/cnx-publishing/cnxpublishing/tests/test_publish.py", line 497, in call_target
    return republish_binders(*args, **kwargs)
  File "/home/karen/cnx-publishing/cnxpublishing/publish.py", line 506, in republish_binders
    rebuild_collection_tree(cursor, ident_hash, history_mapping)
  File "/home/karen/cnx-publishing/cnxpublishing/publish.py", line 688, in rebuild_collection_tree
    build_tree(root_node, None)
  File "/home/karen/cnx-publishing/cnxpublishing/publish.py", line 683, in build_tree
    new_nodeid = insert(data)
  File "/home/karen/cnx-publishing/cnxpublishing/publish.py", line 664, in insert
    cursor.execute(tree_insert_sql, fields)
IntegrityError: duplicate key value violates unique constraint "trees_unique_doc_idx"
DETAIL:  Key (documentid, is_collated)=(5, f) already exists.
```