### PR TITLE
provide token and mathmlcloud URL

### DIFF
--- a/cnxpublishing/scripts/post_publication.py
+++ b/cnxpublishing/scripts/post_publication.py
@@ -132,10 +132,12 @@ def main(argv=sys.argv):
     exercise_url_template = settings.get('embeddables.exercise.url_template',
                                          None)
     exercise_match = settings.get('embeddables.exercise.match', None)
+    exercise_token = settings.get('embeddables.exercise.token', None)
     includes = None
     if exercise_url_template and exercise_match:
         includes = [exercise_callback_factory(exercise_match,
-                                              exercise_url_template)]
+                                              exercise_url_template,
+                                              exercise_token)]
     # Code adapted from
     # http://initd.org/psycopg/docs/advanced.html#asynchronous-notifications
     with psycopg2.connect(connection_string) as conn:

--- a/cnxpublishing/scripts/post_publication.py
+++ b/cnxpublishing/scripts/post_publication.py
@@ -133,11 +133,14 @@ def main(argv=sys.argv):
                                          None)
     exercise_match = settings.get('embeddables.exercise.match', None)
     exercise_token = settings.get('embeddables.exercise.token', None)
+    mathml_url = settings.get('mathmlcloud.url', None)
+
     includes = None
     if exercise_url_template and exercise_match:
         includes = [exercise_callback_factory(exercise_match,
                                               exercise_url_template,
-                                              exercise_token)]
+                                              exercise_token,
+                                              mathml_url)]
     # Code adapted from
     # http://initd.org/psycopg/docs/advanced.html#asynchronous-notifications
     with psycopg2.connect(connection_string) as conn:

--- a/development.ini
+++ b/development.ini
@@ -26,6 +26,9 @@ session_key = 'somkindaseekret'
 embeddables.terp_url_template =  'https://openstaxtutor.org/terp/{itemCode}/quiz_start'
 embeddables.exercise.url_template = 'https://exercises.openstax.org/api/exercises?q=tag:{itemCode}'
 embeddables.exercise.match = '#ost/api/ex/'
+embeddables.exercise.token = 'somesortoftoken'
+
+mathmlcloud.url = 'http://mathmlcloud.cnx.org:1337/equation'
 
 openstax_accounts.stub = true
 openstax_accounts.stub.message_writer = log


### PR DESCRIPTION
Pass through  exercise token and mathmlcloud service URL, if provided in the settings