### PR TITLE
Use notification for view based baking as well

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,11 @@
+[flake8]
+exclude = 
+    .git,
+    .eggs,
+    cnx_publishing.egg-info,
+    build,
+    dist
+
+putty-ignore =
+    cnxpublishing/tests/ : E501, E123, E126, F841
+    */__init__.py : F401, F403

--- a/cnxpublishing/db.py
+++ b/cnxpublishing/db.py
@@ -11,7 +11,6 @@ import sys
 import io
 import functools
 import json
-import uuid
 
 import cnxepub
 import psycopg2
@@ -1085,12 +1084,12 @@ WHERE
 
 
 def upsert_license_requests(cursor, uuid_, roles):
-    """Given a ``uuid`` and list of ``uids`` (user identifiers)
+    """Given a ``uuid`` and list of ``roles`` (user identifiers)
     create a license acceptance entry. If ``has_accepted`` is supplied,
     it will be used to assign an acceptance value to all listed ``uids``.
     """
     if not isinstance(roles, (list, set, tuple,)):
-        raise TypeError("``uids`` is an invalid type: {}".format(type(uids)))
+        raise TypeError("``roles`` is an invalid type: {}".format(type(roles)))
 
     acceptors = set([x['uid'] for x in roles])
 
@@ -1212,7 +1211,7 @@ def remove_role_requests(cursor, uuid_, roles):
     users' role acceptance entries.
     """
     if not isinstance(roles, (list, set, tuple,)):
-        raise TypeError("``roles`` is an invalid type: {}".format(type(uids)))
+        raise TypeError("``roles`` is an invalid type: {}".format(type(roles)))
 
     acceptors = set([(x['uid'], x['role'],) for x in roles])
 

--- a/cnxpublishing/tests/.flake8
+++ b/cnxpublishing/tests/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 1000


### PR DESCRIPTION
This changes the collation view to change the state of the content in the archive to be post_publication, so that the daemon gets a notice and can then process it. This unifies the two paths (publishing and view based trigger), and is critical since I added the transclusion code in the post_publication server, not in the collate method.