### PR TITLE
switch from coveralls to codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,6 @@
+comment:
+  layout: "header, diff, changes, uncovered, tree"
+  behavior: default
+
+# To Turn off comments completely:
+# comment: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,9 +41,9 @@ before_install:
   # * Install cnx-archive
   - git clone https://github.com/Connexions/cnx-archive.git
   - cd cnx-archive && python setup.py install && cd ..
-  # Install the coverage utility and coveralls reporting utility
+  # Install the coverage utility and codecov reporting utility
   - pip install coverage
-  - pip install coveralls
+  - pip install codecov
 install:
   - pip install .
 before_script:
@@ -59,7 +59,7 @@ script:
   # This is the same as `python setup.py test` with a coverage wrapper.
   - coverage run --source=cnxpublishing setup.py test
 after_success:
-  # Report test coverage to coveralls.io
-  - coveralls
+  # Report test coverage to codecov.io
+  - codecov
 notifications:
   email: false

--- a/README.rst
+++ b/README.rst
@@ -14,8 +14,8 @@ Connexions Publishing Service
 .. image:: https://travis-ci.org/Connexions/cnx-publishing.svg
    :target: https://travis-ci.org/Connexions/cnx-publishing
 
-.. image:: https://coveralls.io/repos/Connexions/cnx-publishing/badge.png?branch=master
-  :target: https://coveralls.io/r/Connexions/cnx-publishing?branch=master
+.. image:: https://img.shields.io/codecov/c/github/Connexions/cnx-publishing.svg
+  :target: https://codecov.io/gh/Connexions/cnx-publishing
 
 Interface for:
 
@@ -23,7 +23,7 @@ Interface for:
 - Previewing publication requests
 - Submitting publications to the archive database
 - Accepting or denying role requests
-- Kicking off post-publication jobs 
+- Kicking off post-publication jobs
 - Moderating publications for first time publishers
 
 Getting started


### PR DESCRIPTION
As part of https://github.com/openstax/napkin-notes/issues/68 this switches from coveralls to codecov.

I was not sure about a couple things but took some defaults:

- When should coveralls make comments on the PR and what should be included
- I used this recommendation from codecov.io: https://github.com/codecov/example-python
