### PR TITLE
convert SQL to use ident_hash and module_version funcs, to take advan…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,9 @@ before_install:
   # * Install cnx-archive
   - git clone https://github.com/Connexions/cnx-archive.git
   - cd cnx-archive && python setup.py install && cd ..
+  # * Install cnx-db
+  - git clone https://github.com/Connexions/cnx-db.git
+  - cd cnx-db && python setup.py install && cd ..
   # Install the coverage utility and codecov reporting utility
   - pip install coverage
   - pip install codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,8 @@ before_install:
   - git clone https://github.com/Connexions/cnx-epub.git
   - cd cnx-epub && python setup.py install && cd ..
 
-  # * Install a specific branch of cnx-archive (TODO use master)
-  - git clone -b cnx-db https://github.com/Connexions/cnx-archive.git
+  # * Install cnx-archive
+  - git clone https://github.com/Connexions/cnx-archive.git
   - cd cnx-archive && python setup.py install && cd ..
   # Install the coverage utility and codecov reporting utility
   - pip install coverage

--- a/cnxpublishing/collation.py
+++ b/cnxpublishing/collation.py
@@ -15,7 +15,6 @@ from .publish import (
     publish_collated_tree,
     publish_composite_model,
     )
-from .utils import split_ident_hash
 
 
 @with_db_cursor
@@ -54,8 +53,7 @@ def remove_collation(binder_ident_hash, cursor):
     WITH RECURSIVE t(node, path, is_collated) AS (
     SELECT nodeid, ARRAY[nodeid], is_collated
     FROM trees AS tr, modules AS m
-    WHERE m.uuid::text = %s AND
-          concat_ws('.',  m.major_version, m.minor_version) = %s AND
+    WHERE ident_hash(m.uuid, m.major_version, m.minor_version) = %s AND
       tr.documentid = m.module_ident AND
       tr.parent_id IS NULL AND
       tr.is_collated = TRUE
@@ -65,20 +63,18 @@ UNION ALL
     WHERE not nodeid = any (t.path) AND t.is_collated = c1.is_collated
 )
 delete from trees where nodeid in (select node FROM t)
-    """, split_ident_hash(binder_ident_hash))
+    """, (binder_ident_hash,))
 
     # Remove the collation associations and composite-modules entries.
     cursor.execute("""\
     DELETE FROM collated_file_associations AS cfa
     USING modules AS m
     WHERE
-      (m.uuid = %s
-       AND
-       concat_ws('.', m.major_version, m.minor_version) = %s
+      (ident_hash(m.uuid, m.major_version, m.minor_version) = %s
        )
       AND
       cfa.context = m.module_ident
-    RETURNING item, fileid""", split_ident_hash(binder_ident_hash))
+    RETURNING item, fileid""", (binder_ident_hash,))
     # FIXME (11-May-2016) This can create orphan `files` & `modules` entries,
     #       but since it's not intended to be used in production
     #       this is not a major concern.

--- a/cnxpublishing/scripts/post_publication.py
+++ b/cnxpublishing/scripts/post_publication.py
@@ -62,7 +62,7 @@ def process(cursor, module_ident, ident_hash, includes):
 
     cursor.execute("""\
 SELECT submitter, submitlog FROM modules
-WHERE uuid || '@' || concat_ws('.', major_version, minor_version) = %s""",
+WHERE ident_hash(uuid, major_version, minor_version) = %s""",
                    (ident_hash,))
     publisher, message = cursor.fetchone()
     remove_collation(ident_hash, cursor=cursor)
@@ -95,7 +95,7 @@ FROM (
     ) m
 WHERE m.module_ident = modules.module_ident
 RETURNING modules.module_ident,
-          uuid || '@' || concat_ws('.', major_version, minor_version)""")
+          ident_hash(uuid, major_version, minor_version)""")
             try:
                 module_ident, ident_hash = cursor.fetchone()
             except TypeError:

--- a/cnxpublishing/tests/test_collation.py
+++ b/cnxpublishing/tests/test_collation.py
@@ -35,9 +35,9 @@ WHERE
   AND
   cfa.item = mitem.module_ident
   AND
-  mparent.uuid || '@' || concat_ws('.', mparent.major_version, mparent.minor_version) = %s
+  ident_hash(mparent.uuid, mparent.major_version, mparent.minor_version) = %s
   AND
-  mitem.uuid || '@' || concat_ws('.', mitem.major_version, mitem.minor_version) = %s""",
+  ident_hash(mitem.uuid, mitem.major_version, mitem.minor_version) = %s""",
                        (binder.ident_hash, doc.ident_hash,))
         file = cursor.fetchone()[0]
         return file[:]
@@ -119,9 +119,9 @@ WHERE
   AND
   cfa.item = mitem.module_ident
   AND
-  mparent.uuid || '@' || concat_ws('.', mparent.major_version, mparent.minor_version) = %s
+   ident_hash(mparent.uuid, mparent.major_version, mparent.minor_version) = %s
   AND
-  mitem.uuid || '@' || concat_ws('.', mitem.major_version, mitem.minor_version) = %s""",
+   ident_hash(mitem.uuid, mitem.major_version, mitem.minor_version) = %s""",
                        (binder.ident_hash, doc.ident_hash,))
         sha1 = cursor.fetchone()[0]
         return sha1
@@ -188,6 +188,7 @@ WHERE
         self.assertEqual(collated_tree, None)
 
         # Ensure the collated files relationship is removed.
-        cursor.execute("SELECT * FROM collated_file_associations AS cfa NATURAL JOIN modules AS m WHERE m.uuid = %s AND concat_ws('.', m.major_version, m.minor_version) = %s", (id, version,))
+        cursor.execute("SELECT * FROM collated_file_associations AS cfa NATURAL JOIN modules AS m "
+                       "WHERE ident_hash(m.uuid, m.major_version, m.minor_version) = %s", (self.ident_hash,))
         with self.assertRaises(TypeError):
             rows = cursor.fetchone()[0]

--- a/cnxpublishing/tests/use_cases.py
+++ b/cnxpublishing/tests/use_cases.py
@@ -558,7 +558,7 @@ def check_BOOK_in_archive(test_case, cursor):
         names)
 
     cursor.execute("""\
-SELECT portal_type, uuid||'@'||concat_ws('.',major_version,minor_version)
+SELECT portal_type, ident_hash(uuid,major_version,minor_version)
 FROM modules""")
     items = dict(cursor.fetchall())
     document_ident_hash = items['Module']
@@ -566,7 +566,7 @@ FROM modules""")
 
     cursor.execute("""\
 SELECT portal_type,
-       short_id(uuid)||'@'||concat_ws('.', major_version, minor_version)
+       short_ident_hash(uuid, major_version, minor_version)
 FROM modules""")
     items = dict(cursor.fetchall())
     document_short_id = items['Module']
@@ -589,7 +589,7 @@ FROM modules""")
                        "shortId": document_short_id,
                        "title": "Document One"}]}]}]}
     cursor.execute("""\
- SELECT tree_to_json(uuid::text, concat_ws('.',major_version, minor_version), FALSE)
+ SELECT tree_to_json(uuid::text, module_version(major_version, minor_version), FALSE)
 FROM modules
 WHERE portal_type = 'Collection'""")
     tree = json.loads(cursor.fetchone()[0])
@@ -606,7 +606,7 @@ WHERE portal_type = 'Collection'""")
                       .hexdigest()
     cursor.execute("""\
 SELECT f.file, f.media_type,
-       m.uuid||'@'||concat_ws('.',m.major_version,m.minor_version)
+        ident_hash(m.uuid,m.major_version,m.minor_version)
 FROM files as f natural join module_files as mf, latest_modules as m
 WHERE
   mf.module_ident = m.module_ident
@@ -672,7 +672,7 @@ FROM modules ORDER BY major_version ASC""")
                   u"shortId": u"EeLmMXO1@2",
                   u"title": REVISED_BOOK[0].get_title_for_node(document)}]}]}
     cursor.execute("""\
-SELECT tree_to_json(uuid::text, concat_ws('.', major_version, minor_version), FALSE)
+SELECT tree_to_json(uuid::text, module_version(major_version, minor_version), FALSE)
 FROM latest_modules
 WHERE portal_type = 'Collection'""")
     tree = json.loads(cursor.fetchone()[0])
@@ -689,7 +689,7 @@ WHERE portal_type = 'Collection'""")
                       .hexdigest()
     cursor.execute("""\
 SELECT f.file, f.media_type,
-       m.uuid||'@'||concat_ws('.',m.major_version,m.minor_version)
+        ident_hash(m.uuid,m.major_version,m.minor_version)
 FROM files as f natural join module_files as mf, latest_modules as m
 WHERE
   mf.module_ident = m.module_ident
@@ -723,7 +723,7 @@ def _is_published(ident_hash, cursor):
     cursor.execute("""\
 SELECT module_ident
 FROM modules
-WHERE uuid||'@'||concat_ws('.', major_version, minor_version) = %s""",
+WHERE ident_hash(uuid, major_version, minor_version) = %s""",
                    (ident_hash,))
     try:
         ident = cursor.fetchone()[0]

--- a/cnxpublishing/tests/views/test_publishing.py
+++ b/cnxpublishing/tests/views/test_publishing.py
@@ -1157,7 +1157,7 @@ FROM modules ORDER BY major_version ASC""")
                               u"shortId": u"EeLmMXO1@1",
                               u"title": use_cases.REVISED_BOOK[0].get_title_for_node(document)}]}]}
                 cursor.execute("""\
-SELECT tree_to_json(uuid::text, concat_ws('.', major_version, minor_version), FALSE)
+SELECT tree_to_json(uuid::text, module_version( major_version, minor_version), FALSE)
 FROM latest_modules
 WHERE portal_type = 'Collection'""")
                 tree = json.loads(cursor.fetchone()[0])

--- a/cnxpublishing/views/admin.py
+++ b/cnxpublishing/views/admin.py
@@ -66,7 +66,7 @@ def admin_post_publications(request):
     with psycopg2.connect(db_conn_str) as db_conn:
         with db_conn.cursor() as cursor:
             cursor.execute("""\
-SELECT m.uuid || '@' || concat_ws('.', m.major_version, m.minor_version),
+SELECT ident_hash(m.uuid, m.major_version, m.minor_version),
        m.name, p.timestamp, p.state, p.state_message
   FROM post_publications p NATURAL LEFT JOIN modules m
   ORDER BY p.timestamp DESC LIMIT 500""")

--- a/cnxpublishing/views/publishing.py
+++ b/cnxpublishing/views/publishing.py
@@ -95,7 +95,7 @@ def get_accept_license(request):
 SELECT row_to_json(combined_rows) FROM (
 SELECT
   pd.uuid AS id,
-  pd.uuid||'@'||concat_ws('.', pd.major_version, pd.minor_version) \
+  ident_hash(pd.uuid, pd.major_version, pd.minor_version) \
     AS ident_hash,
   accepted AS is_accepted
 FROM
@@ -175,7 +175,7 @@ def get_accept_role(request):
 SELECT row_to_json(combined_rows) FROM (
 SELECT
   pd.uuid AS id,
-  pd.uuid||'@'||concat_ws('.', pd.major_version, pd.minor_version) \
+  ident_hash(pd.uuid, pd.major_version, pd.minor_version) \
     AS ident_hash,
   accepted AS is_accepted
 FROM
@@ -258,8 +258,8 @@ def collate_content(request):
             if version:
                 cursor.execute("""\
 UPDATE modules SET stateid = 5
-WHERE uuid = %s AND concat_ws('.', major_version, minor_version) = %s
-""", (id, version,))
+WHERE ident_hash(uuid, major_version, minor_version) = %s
+""", (ident_hash,))
             else:
                 cursor.execute("""\
 UPDATE modules SET stateid = 5 where module_ident in (select module_ident from


### PR DESCRIPTION
…tage of indexes
There are significant performance issues with matching against uuid and composite version without these. In particular, the code in collation that make document_acl and other entries (collated_file_associations) retail runs to 300-400 ms per entry, for thousands of entries, leading to long on-server-baking times.
 Depends on https://github.com/Connexions/cnx-db/pull/13.  Rerun tests after that PR is merged.