### PR TITLE
quotes in config passed as part of value, breaking exercise retrieval

### DIFF
--- a/development.ini
+++ b/development.ini
@@ -23,12 +23,12 @@ file-upload-limit = 50
 
 session_key = 'somkindaseekret'
 
-embeddables.terp_url_template =  'https://openstaxtutor.org/terp/{itemCode}/quiz_start'
-embeddables.exercise.url_template = 'https://exercises.openstax.org/api/exercises?q=tag:{itemCode}'
-embeddables.exercise.match = '#ost/api/ex/'
-embeddables.exercise.token = 'somesortoftoken'
+embeddables.terp_url_template =  https://openstaxtutor.org/terp/{itemCode}/quiz_start
+embeddables.exercise.url_template = https://exercises.openstax.org/api/exercises?q=tag:{itemCode}
+embeddables.exercise.match = #ost/api/ex/
+embeddables.exercise.token = 
 
-mathmlcloud.url = 'http://mathmlcloud.cnx.org:1337/equation'
+mathmlcloud.url = http://mathmlcloud.cnx.org:1337/equation
 
 openstax_accounts.stub = true
 openstax_accounts.stub.message_writer = log


### PR DESCRIPTION
Same as cnx-deploy, the defaults given in development.ini don't work.