### PR TITLE
use memcache the same way as archive

### DIFF
--- a/cnxpublishing/bake.py
+++ b/cnxpublishing/bake.py
@@ -32,12 +32,16 @@ def _formatter_callback_factory():  # pragma: no cover
     exercise_match = settings.get('embeddables.exercise.match', None)
     exercise_token = settings.get('embeddables.exercise.token', None)
     mathml_url = settings.get('mathmlcloud.url', None)
-    memcache_server = settings.get('memcache_server', None)
+    memcache_servers = settings.get('memcache_servers')
+    if memcache_servers:
+        memcache_servers = memcache_servers.split()
+    else:
+        memcache_servers = None
 
     if exercise_url_template and exercise_match:
         mc_client = None
-        if memcache_server:
-            mc_client = memcache.Client([memcache_server], debug=0)
+        if memcache_servers:
+            mc_client = memcache.Client(memcache_servers, debug=0)
         includes.append(exercise_callback_factory(exercise_match,
                                                   exercise_url_template,
                                                   mc_client,

--- a/development.ini
+++ b/development.ini
@@ -29,7 +29,7 @@ embeddables.exercise.match = #ost/api/ex/
 embeddables.exercise.token = 
 
 mathmlcloud.url = http://mathmlcloud.cnx.org:1337/equation
-memcache_server = localhost:11211
+memcache_servers = localhost
 
 openstax_accounts.stub = true
 openstax_accounts.stub.message_writer = log


### PR DESCRIPTION
By making the config name the sme (and allowing for more than one server) we make cnx-deploy easier to understand and write.