### PR TITLE
Optimize re-baking request

### DIFF
--- a/cnxpublishing/tests/views/test_publishing.py
+++ b/cnxpublishing/tests/views/test_publishing.py
@@ -1473,3 +1473,12 @@ class BakeContentTestCase(BaseFunctionalViewTestCase):
                                   expect_errors=True)
         self.assertEquals(resp.status_int, 400)
         self.assertIn('must specify the version', resp.body)
+
+    @db_connect
+    def test_bad_ident_hash(self, cursor):
+        api_key_headers = self.gen_api_key_headers('some-trust')
+        ident_hash = 'f00ba7@1.1'
+
+        resp = self.app_post_bake(ident_hash, headers=api_key_headers,
+                                  expect_errors=True)
+        self.assertEquals(resp.status_int, 404)

--- a/cnxpublishing/views/publishing.py
+++ b/cnxpublishing/views/publishing.py
@@ -5,9 +5,10 @@
 # Public License version 3 (AGPLv3).
 # See LICENCE.txt for details.
 # ###
-from cnxarchive.scripts import export_epub
 import cnxepub
 import psycopg2
+from cnxarchive.scripts import export_epub
+from cnxarchive.utils.ident_hash import IdentHashError
 from pyramid import httpexceptions
 from pyramid.settings import asbool
 from pyramid.view import view_config
@@ -246,7 +247,11 @@ def bake_content(request):
     """Invoke the baking process - trigger post-publication"""
     settings = request.registry.settings
     ident_hash = request.matchdict['ident_hash']
-    id, version = split_ident_hash(ident_hash)
+    try:
+        id, version = split_ident_hash(ident_hash)
+    except IdentHashError:
+        raise httpexceptions.HTTPNotFound()
+
     if not version:
         raise httpexceptions.HTTPBadRequest('must specify the version')
 


### PR DESCRIPTION
This removes the creation of the epub and the removal of the content. We may want to leave the removal in as a way to analyze the state, since we don't have a direct access to that information yet. I've chosen to remove it for the time being, because the baking process removes it.