### PR TITLE
New content view

### DIFF
--- a/cnxpublishing/tests/views/test_admin.py
+++ b/cnxpublishing/tests/views/test_admin.py
@@ -270,6 +270,7 @@ class ContentStatusViewsTestCase(unittest.TestCase):
             'page': 1,
             'num_entries': 100,
             'sort': 'bpsa.created DESC',
+            'sort_created': 'fa fa-angle-down',
             'states': content['states']
         }, content)
         self.assertEqual(len(content['states']), 2)
@@ -296,6 +297,7 @@ class ContentStatusViewsTestCase(unittest.TestCase):
             'num_entries': 2,
             'author': 'charrose',
             'sort': 'STATE ASC',
+            'sort_state': 'fa fa-angle-up',
             'states': content['states']
         }, content)
         self.assertEqual(len(content['states']), 2)

--- a/cnxpublishing/tests/views/test_admin.py
+++ b/cnxpublishing/tests/views/test_admin.py
@@ -410,7 +410,6 @@ class ContentStatusViewsTestCase(unittest.TestCase):
         self.assertEqual('PENDING stale_recipe stale_content',
                          content['states'][0]['state'])
 
-
     def test_admin_content_status_single_page_POST_already_baking(self):
         uuid = 'd5dbbd8e-d137-4f89-9d0a-3ac8db53d8ee'
         with psycopg2.connect(self.db_conn_str) as db_conn:

--- a/cnxpublishing/tests/views/test_admin.py
+++ b/cnxpublishing/tests/views/test_admin.py
@@ -244,6 +244,10 @@ class ContentStatusViewsTestCase(unittest.TestCase):
     def setUp(self):
         self.config = testing.setUp(settings=self.settings)
         self.config.include('cnxpublishing.tasks')
+        self.config.add_route('admin-content-status-single',
+                              '/a/content-status/{uuid}')
+        self.config.add_route('get-content', '/contents/{ident_hash}')
+
         init_db(self.db_conn_str, True)
         add_data(self)
 
@@ -314,12 +318,14 @@ class ContentStatusViewsTestCase(unittest.TestCase):
 
         from ...views.admin import admin_content_status_single
         content = admin_content_status_single(request)
+        print(content)
+        print(content['current_ident'])
         self.assertEqual({
             'uuid': uuid,
             'title': 'Book of Infinity',
             'authors': 'marknewlyn, charrose',
             'print_style': None,
-            'current_recipie': None,
+            'current_recipe': None,
             'current_ident': 2,
             'current_state': u'PENDING stale_content',
             'states': [
@@ -336,7 +342,6 @@ class ContentStatusViewsTestCase(unittest.TestCase):
             ]
         }, content)
 
-    @unittest.skip("celery is too global, run one at a time")
     def test_admin_content_status_single_page_POST(self):
         request = testing.DummyRequest()
         from ...views.admin import admin_content_status_single_POST

--- a/cnxpublishing/tests/views/test_admin.py
+++ b/cnxpublishing/tests/views/test_admin.py
@@ -19,6 +19,31 @@ from ..testing import (
     )
 
 
+def add_data(self):
+    with self.db_connect() as db_conn:
+        with db_conn.cursor() as cursor:
+            # Insert one book into archive.
+            book = use_cases.setup_BOOK_in_archive(self, cursor)
+            db_conn.commit()
+
+            # Insert some data into the association table.
+            cursor.execute("""
+            INSERT INTO document_baking_result_associations
+            (result_id, module_ident)
+            SELECT
+            uuid_generate_v4(),
+            (SELECT module_ident FROM modules ORDER BY module_ident DESC LIMIT 1);""")
+            db_conn.commit()
+
+            cursor.execute("""\
+            INSERT INTO document_baking_result_associations
+            (result_id, module_ident)
+            SELECT
+            uuid_generate_v4(),
+            (SELECT module_ident FROM modules ORDER BY module_ident DESC LIMIT 1);""")
+    return book
+
+
 @pytest.mark.usefixtures('scoped_pyramid_app')
 class PostPublicationsViewsTestCase(unittest.TestCase):
     maxDiff = None
@@ -35,6 +60,7 @@ class PostPublicationsViewsTestCase(unittest.TestCase):
         from ...views.admin import admin_post_publications
         return admin_post_publications
 
+    @unittest.skip("celery is too global, run one at a time")
     def test_no_results(self):
         request = testing.DummyRequest()
 
@@ -42,30 +68,11 @@ class PostPublicationsViewsTestCase(unittest.TestCase):
 
         self.assertEqual({'states': []}, resp_data)
 
+    @unittest.skip("celery is too global, run one at a time")
     def test(self):
         request = testing.DummyRequest()
 
-        with self.db_connect() as db_conn:
-            with db_conn.cursor() as cursor:
-                # Insert one book into archive.
-                book = use_cases.setup_BOOK_in_archive(self, cursor)
-                db_conn.commit()
-
-                # Insert some data into the association table.
-                cursor.execute("""
-INSERT INTO document_baking_result_associations
-  (result_id, module_ident)
-SELECT
-  uuid_generate_v4(),
-  (SELECT module_ident FROM modules ORDER BY module_ident DESC LIMIT 1);""")
-                db_conn.commit()
-
-                cursor.execute("""\
-INSERT INTO document_baking_result_associations
-  (result_id, module_ident)
-SELECT
-  uuid_generate_v4(),
-  (SELECT module_ident FROM modules ORDER BY module_ident DESC LIMIT 1);""")
+        book = add_data(self)
 
         resp_data = self.target(request)
         self.assertEqual({
@@ -215,3 +222,103 @@ class SiteMessageViewsTestCase(unittest.TestCase):
                           'end_date': '2017-01-03',
                           'end_time': '00:03',
                           'id': '1'}, results)
+
+
+# FIXME There is an issue with setting up the celery app more than once.
+#       Apparently, creating the app a second time doesn't really create
+#       it again. There is some global state hanging around that we can't
+#       easily get at. This causes the task results tables used in these
+#       views to not exist, because the code believes it's already been
+#       initialized.
+@unittest.skip("celery is too global")
+class ContentStatusViewsTestCase(unittest.TestCase):
+    maxDiff = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.settings = integration_test_settings()
+        from cnxpublishing.config import CONNECTION_STRING
+        cls.db_conn_str = cls.settings[CONNECTION_STRING]
+        cls.db_connect = staticmethod(db_connection_factory())
+
+    def setUp(self):
+        self.config = testing.setUp(settings=self.settings)
+        self.config.include('cnxpublishing.tasks')
+        init_db(self.db_conn_str, True)
+        add_data(self)
+
+    def tearDown(self):
+        with self.db_connect() as db_conn:
+            with db_conn.cursor() as cursor:
+                cursor.execute("DROP SCHEMA public CASCADE")
+                cursor.execute("CREATE SCHEMA public")
+        testing.tearDown()
+
+
+    def test_admin_content_status_no_filters(self):
+        request = testing.DummyRequest()
+
+        from ...views.admin import admin_content_status
+        content = admin_content_status(request)
+        self.assertEqual({
+            'SUCCESS': 'checked',
+            'PENDING': 'checked',
+            'STARTED': 'checked',
+            'RETRY': 'checked',
+            'FAILURE': 'checked',
+            'start_entry': 0,
+            'page': 1,
+            'num_entries': 100,
+            'sort': 'bpsa.created DESC',
+            'states': content['states']
+        }, content)
+        self.assertEqual(len(content['states']), 2)
+        self.assertEqual(
+            content['states'],
+            sorted(content['states'], key=lambda x: x['created'], reverse=True))
+
+    def test_admin_content_status_w_filters(self):
+        request = testing.DummyRequest()
+
+        request.GET = {'page': 1,
+                       'number': 2,
+                       'sort': 'STATE ASC',
+                       'author': 'charrose',
+                       'exculde_statuses': 'SUCCESS,STARTED'}
+        from ...views.admin import admin_content_status
+        content = admin_content_status(request)
+        self.assertEqual({
+            'FAILURE': 'checked',
+            'RETRY': 'checked',
+            'PENDING': 'checked',
+            'start_entry': 0,
+            'page': 1,
+            'num_entries': 2,
+            'author': 'charrose',
+            'sort': 'STATE ASC',
+            'states': content['states']
+        }, content)
+        self.assertEqual(len(content['states']), 2)
+        for state in content['states']:
+            self.assertTrue('charrose' in state['authors'])
+            self.assertTrue(state['state'] not in ['STARTED', 'SUCCESS'])
+        self.assertEqual(
+            content['states'],
+            sorted(content['states'], key=lambda x: x['state']))
+
+    def test_admin_content_status_single_page(self):
+        request = testing.DummyRequest()
+
+        ident = 'd5dbbd8e-d137-4f89-9d0a-3ac8db53d8ee@1.1'
+        request.matchdict['ident_hash'] = ident
+
+        from ...views.admin import admin_content_status_single
+        content = admin_content_status_single(request)
+        self.assertEqual({
+            'ident_hash': ident,
+            'title': 'Book of Infinity',
+            'authors': 'marknewlyn, charrose',
+            'created': content['created'],
+            'state': 'PENDING',
+            'state_message': '',
+        }, content)

--- a/cnxpublishing/tests/views/test_admin.py
+++ b/cnxpublishing/tests/views/test_admin.py
@@ -60,7 +60,6 @@ class PostPublicationsViewsTestCase(unittest.TestCase):
         from ...views.admin import admin_post_publications
         return admin_post_publications
 
-    @unittest.skip("celery is too global, run one at a time")
     def test_no_results(self):
         request = testing.DummyRequest()
 
@@ -68,7 +67,6 @@ class PostPublicationsViewsTestCase(unittest.TestCase):
 
         self.assertEqual({'states': []}, resp_data)
 
-    @unittest.skip("celery is too global, run one at a time")
     def test(self):
         request = testing.DummyRequest()
 
@@ -224,13 +222,7 @@ class SiteMessageViewsTestCase(unittest.TestCase):
                           'id': '1'}, results)
 
 
-# FIXME There is an issue with setting up the celery app more than once.
-#       Apparently, creating the app a second time doesn't really create
-#       it again. There is some global state hanging around that we can't
-#       easily get at. This causes the task results tables used in these
-#       views to not exist, because the code believes it's already been
-#       initialized.
-@unittest.skip("celery is too global")
+@pytest.mark.usefixtures('scoped_pyramid_app')
 class ContentStatusViewsTestCase(unittest.TestCase):
     maxDiff = None
 
@@ -248,15 +240,7 @@ class ContentStatusViewsTestCase(unittest.TestCase):
                               '/a/content-status/{uuid}')
         self.config.add_route('get-content', '/contents/{ident_hash}')
 
-        init_db(self.db_conn_str, True)
         add_data(self)
-
-    def tearDown(self):
-        with self.db_connect() as db_conn:
-            with db_conn.cursor() as cursor:
-                cursor.execute("DROP SCHEMA public CASCADE")
-                cursor.execute("CREATE SCHEMA public")
-        testing.tearDown()
 
     def test_admin_content_status_no_filters(self):
         request = testing.DummyRequest()

--- a/cnxpublishing/tests/views/test_admin.py
+++ b/cnxpublishing/tests/views/test_admin.py
@@ -298,6 +298,24 @@ class ContentStatusViewsTestCase(unittest.TestCase):
             content['states'],
             sorted(content['states'], key=lambda x: x['state']))
 
+    def test_admin_content_status_stale_recipe(self):
+        uuid = 'd5dbbd8e-d137-4f89-9d0a-3ac8db53d8ee'
+        with psycopg2.connect(self.db_conn_str) as db_conn:
+            with db_conn.cursor() as cursor:
+                cursor.execute("""\
+                    UPDATE modules SET recipe=1
+                    WHERE uuid=%s;
+                    """, (uuid, ))
+
+        request = testing.DummyRequest()
+        request.GET = {'page': 1,
+                       'number': 1}
+        from ...views.admin import admin_content_status
+        content = admin_content_status(request)
+        print [x['state'] for x in content['states']]
+        self.assertEqual('PENDING stale_content stale_recipe',
+                         content['states'][0]['state'])
+
     def test_admin_content_status_bad_sort(self):
         request = testing.DummyRequest()
 

--- a/cnxpublishing/tests/views/test_admin.py
+++ b/cnxpublishing/tests/views/test_admin.py
@@ -257,6 +257,7 @@ class ContentStatusViewsTestCase(unittest.TestCase):
 
     def test_admin_content_status_no_filters(self):
         request = testing.DummyRequest()
+
         from ...views.admin import admin_content_status
         content = admin_content_status(request)
         self.assertEqual({
@@ -269,7 +270,7 @@ class ContentStatusViewsTestCase(unittest.TestCase):
             'page': 1,
             'num_entries': 100,
             'sort': 'bpsa.created DESC',
-            'newSort': 'selected',
+            'sort_created': 'fa fa-angle-down',
             'states': content['states']
         }, content)
         self.assertEqual(len(content['states']), 2)
@@ -282,7 +283,7 @@ class ContentStatusViewsTestCase(unittest.TestCase):
 
         request.GET = {'page': 1,
                        'number': 2,
-                       'sort': 'STATE',
+                       'sort': 'STATE ASC',
                        'author': 'charrose',
                        'status_filter': ['FAILURE', 'RETRY', 'PENDING']}
         from ...views.admin import admin_content_status
@@ -295,8 +296,8 @@ class ContentStatusViewsTestCase(unittest.TestCase):
             'page': 1,
             'num_entries': 2,
             'author': 'charrose',
-            'sort': 'bpsa.created DESC',
-            'stateSort': 'selected',
+            'sort': 'STATE ASC',
+            'sort_state': 'fa fa-angle-up',
             'states': content['states']
         }, content)
         self.assertEqual(len(content['states']), 2)

--- a/cnxpublishing/tests/views/test_admin.py
+++ b/cnxpublishing/tests/views/test_admin.py
@@ -377,7 +377,6 @@ class ContentStatusViewsTestCase(unittest.TestCase):
                     WHERE uuid=%s;
                     """, (uuid, ))
 
-
         request = testing.DummyRequest()
         from ...views.admin import admin_content_status_single_POST
 

--- a/cnxpublishing/tests/views/test_admin.py
+++ b/cnxpublishing/tests/views/test_admin.py
@@ -318,8 +318,6 @@ class ContentStatusViewsTestCase(unittest.TestCase):
 
         from ...views.admin import admin_content_status_single
         content = admin_content_status_single(request)
-        print(content)
-        print(content['current_ident'])
         self.assertEqual({
             'uuid': uuid,
             'title': 'Book of Infinity',

--- a/cnxpublishing/tests/views/test_admin.py
+++ b/cnxpublishing/tests/views/test_admin.py
@@ -257,7 +257,6 @@ class ContentStatusViewsTestCase(unittest.TestCase):
 
     def test_admin_content_status_no_filters(self):
         request = testing.DummyRequest()
-
         from ...views.admin import admin_content_status
         content = admin_content_status(request)
         self.assertEqual({
@@ -270,7 +269,7 @@ class ContentStatusViewsTestCase(unittest.TestCase):
             'page': 1,
             'num_entries': 100,
             'sort': 'bpsa.created DESC',
-            'sort_created': 'fa fa-angle-down',
+            'newSort': 'selected',
             'states': content['states']
         }, content)
         self.assertEqual(len(content['states']), 2)
@@ -283,9 +282,9 @@ class ContentStatusViewsTestCase(unittest.TestCase):
 
         request.GET = {'page': 1,
                        'number': 2,
-                       'sort': 'STATE ASC',
+                       'sort': 'STATE',
                        'author': 'charrose',
-                       'exculde_statuses': 'SUCCESS,STARTED'}
+                       'status_filter': ['FAILURE', 'RETRY', 'PENDING']}
         from ...views.admin import admin_content_status
         content = admin_content_status(request)
         self.assertEqual({
@@ -296,8 +295,8 @@ class ContentStatusViewsTestCase(unittest.TestCase):
             'page': 1,
             'num_entries': 2,
             'author': 'charrose',
-            'sort': 'STATE ASC',
-            'sort_state': 'fa fa-angle-up',
+            'sort': 'bpsa.created DESC',
+            'stateSort': 'selected',
             'states': content['states']
         }, content)
         self.assertEqual(len(content['states']), 2)

--- a/cnxpublishing/tests/views/test_admin.py
+++ b/cnxpublishing/tests/views/test_admin.py
@@ -311,16 +311,24 @@ class ContentStatusViewsTestCase(unittest.TestCase):
     def test_admin_content_status_single_page(self):
         request = testing.DummyRequest()
 
-        ident = 'd5dbbd8e-d137-4f89-9d0a-3ac8db53d8ee@1.1'
-        request.matchdict['ident_hash'] = ident
+        uuid = 'd5dbbd8e-d137-4f89-9d0a-3ac8db53d8ee'
+        request.matchdict['uuid'] = uuid
 
         from ...views.admin import admin_content_status_single
         content = admin_content_status_single(request)
+        print(content)
         self.assertEqual({
-            'ident_hash': ident,
+            'uuid': uuid,
             'title': 'Book of Infinity',
             'authors': 'marknewlyn, charrose',
-            'created': content['created'],
-            'state': 'PENDING',
-            'state_message': '',
+            'states': [
+                {'ident_hash': content['states'][0]['ident_hash'],
+                 'created': content['states'][0]['created'],
+                 'state': 'PENDING',
+                 'state_message': ''},
+                {'ident_hash': content['states'][1]['ident_hash'],
+                 'created': content['states'][1]['created'],
+                 'state': 'PENDING',
+                 'state_message': ''}
+            ]
         }, content)

--- a/cnxpublishing/views/__init__.py
+++ b/cnxpublishing/views/__init__.py
@@ -55,8 +55,12 @@ def declare_browsable_routes(config):
               request_method='GET')
     add_route('admin-edit-site-message-POST', '/a/site-messages/{id}/',
               request_method='POST')
+
     add_route('admin-content-status', '/a/content-status/')
-    add_route('admin-content-status-single', '/a/content-status/{uuid}')
+    add_route('admin-content-status-single', '/a/content-status/{uuid}',
+              request_method='GET')
+    add_route('admin-content-status-single-POST', '/a/content-status/{uuid}',
+              request_method='POST')
 
 
 def includeme(config):

--- a/cnxpublishing/views/__init__.py
+++ b/cnxpublishing/views/__init__.py
@@ -55,6 +55,8 @@ def declare_browsable_routes(config):
               request_method='GET')
     add_route('admin-edit-site-message-POST', '/a/site-messages/{id}/',
               request_method='POST')
+    add_route('admin-content-status', '/a/content-status/')
+    add_route('admin-content-status-single', '/a/content-status/{ident_hash}')
 
 
 def includeme(config):

--- a/cnxpublishing/views/__init__.py
+++ b/cnxpublishing/views/__init__.py
@@ -57,10 +57,7 @@ def declare_browsable_routes(config):
               request_method='POST')
 
     add_route('admin-content-status', '/a/content-status/')
-    add_route('admin-content-status-single', '/a/content-status/{uuid}',
-              request_method='GET')
-    add_route('admin-content-status-single-POST', '/a/content-status/{uuid}',
-              request_method='POST')
+    add_route('admin-content-status-single', '/a/content-status/{uuid}')
 
 
 def includeme(config):

--- a/cnxpublishing/views/__init__.py
+++ b/cnxpublishing/views/__init__.py
@@ -56,7 +56,7 @@ def declare_browsable_routes(config):
     add_route('admin-edit-site-message-POST', '/a/site-messages/{id}/',
               request_method='POST')
     add_route('admin-content-status', '/a/content-status/')
-    add_route('admin-content-status-single', '/a/content-status/{ident_hash}')
+    add_route('admin-content-status-single', '/a/content-status/{uuid}')
 
 
 def includeme(config):

--- a/cnxpublishing/views/admin.py
+++ b/cnxpublishing/views/admin.py
@@ -30,6 +30,13 @@ STATE_ICONS = {
               'style': 'font-size:20px;color:red'},
     "FAILURE": {'class': 'fa fa-close',
                 'style': 'font-size:20px;color:red'}}
+SORTS_DICT = {
+    "bpsa.created": 'created',
+    "m.name": 'name',
+    "STATE": 'state'}
+ARROW_MATCH = {
+    "ASC": 'fa fa-angle-up',
+    "DESC": 'fa fa-angle-down'}
 
 
 @view_config(route_name='admin-index', request_method='GET',
@@ -302,8 +309,8 @@ def get_baking_statuses_sql(request):
             format(page, num_entries))
     sort = request.GET.get('sort', 'bpsa.created DESC')
     if (len(sort.split(" ")) != 2 or
-            sort.split(" ")[0] not in ['bpsa.created', 'STATE', 'm.name'] or
-            sort.split(" ")[1] not in ['ASC', 'DESC']):
+            sort.split(" ")[0] not in SORTS_DICT.keys() or
+            sort.split(" ")[1] not in ARROW_MATCH.keys()):
         raise httpexceptions.HTTPBadRequest(
             'invalid sort: {}'.format(sort))
     if sort == "STATE ASC" or sort == "STATE DESC":
@@ -387,6 +394,8 @@ def admin_content_status(request):
         if not(state['state'] in status_filters):
             final_states.append(state)
     sort = request.GET.get('sort', 'bpsa.created DESC')
+    sort_match = SORTS_DICT[sort.split(' ')[0]]
+    args['sort_' + sort_match] = ARROW_MATCH[sort.split(' ')[1]]
     args['sort'] = sort
     if sort == "STATE ASC":
         final_states = sorted(final_states, key=lambda x: x['state'])

--- a/cnxpublishing/views/admin.py
+++ b/cnxpublishing/views/admin.py
@@ -387,14 +387,14 @@ def admin_content_status(request):
         if not(state['state'] in status_filters):
             final_states.append(state)
     sort = request.GET.get('sort', 'bpsa.created DESC')
-
+    args['sort'] = sort
     if sort == "STATE ASC":
-        sorted(final_states, key=lambda x: x['state'])
+        final_states = sorted(final_states, key=lambda x: x['state'])
     if sort == "STATE DESC":
-        sorted(final_states, key=lambda x: x['state'], reverse=True)
+        final_states = sorted(final_states,
+                              key=lambda x: x['state'], reverse=True)
 
     args.update({'states': final_states})
-    print(args)
     return args
 
 
@@ -415,7 +415,7 @@ def admin_content_status_single(request):
                 WHERE ident_hash(m.uuid, m.major_version, m.minor_version)=%s;
                     """, vars=(ident_hash,))
             modules = cursor.fetchall()
-            if len(modules) != 1:
+            if len(modules) == 0:
                 raise httpexceptions.HTTPBadRequest(
                     '{} is not a book'.format(ident_hash))
             row = modules[0]

--- a/cnxpublishing/views/admin.py
+++ b/cnxpublishing/views/admin.py
@@ -31,10 +31,12 @@ STATE_ICONS = {
     "FAILURE": {'class': 'fa fa-close',
                 'style': 'font-size:20px;color:red'}}
 SORTS_DICT = {
-    "bpsa.created DESC": 'newSort',
-    "bpsa.created ASC": 'oldSort',
-    "m.name": 'nameSort',
-    "STATE": 'stateSort'}
+    "bpsa.created": 'created',
+    "m.name": 'name',
+    "STATE": 'state'}
+ARROW_MATCH = {
+    "ASC": 'fa fa-angle-up',
+    "DESC": 'fa fa-angle-down'}
 
 
 @view_config(route_name='admin-index', request_method='GET',
@@ -296,7 +298,6 @@ def admin_edit_site_message_POST(request):
 
 def get_baking_statuses_sql(request):
     args = {}
-
     num_entries = request.GET.get('number', 100)
     page = request.GET.get('page', 1)
     try:
@@ -306,11 +307,12 @@ def get_baking_statuses_sql(request):
             'invalid page({}) or entries per page({})'.
             format(page, num_entries))
     sort = request.GET.get('sort', 'bpsa.created DESC')
-    if sort not in SORTS_DICT.keys():
+    if (len(sort.split(" ")) != 2 or
+            sort.split(" ")[0] not in SORTS_DICT.keys() or
+            sort.split(" ")[1] not in ARROW_MATCH.keys()):
         raise httpexceptions.HTTPBadRequest(
-            'invalid sort({})'.format(sort))
-    args[SORTS_DICT[sort]] = 'selected'
-    if sort == "STATE":
+            'invalid sort: {}'.format(sort))
+    if sort == "STATE ASC" or sort == "STATE DESC":
         sort = 'bpsa.created DESC'
     ident_hash_filter = request.GET.get('ident_hash', '')
     author_filter = request.GET.get('author', '')
@@ -390,9 +392,16 @@ def admin_content_status(request):
     for state in states:
         if state['state'] in status_filters:
             final_states.append(state)
+
     sort = request.GET.get('sort', 'bpsa.created DESC')
-    if sort == "STATE":
+    sort_match = SORTS_DICT[sort.split(' ')[0]]
+    args['sort_' + sort_match] = ARROW_MATCH[sort.split(' ')[1]]
+    args['sort'] = sort
+    if sort == "STATE ASC":
         final_states = sorted(final_states, key=lambda x: x['state'])
+    if sort == "STATE DESC":
+        final_states = sorted(final_states,
+                              key=lambda x: x['state'], reverse=True)
 
     args.update({'states': final_states})
     return args

--- a/cnxpublishing/views/admin.py
+++ b/cnxpublishing/views/admin.py
@@ -14,9 +14,15 @@ from celery.result import AsyncResult
 from pyramid import httpexceptions
 from pyramid.view import view_config
 
+from cnxarchive.utils.ident_hash import IdentHashError
 from .. import config
 from .moderation import get_moderation
 from .api_keys import get_api_keys
+
+SORT_MAP = {"bpsa.created DESC": "newSort",
+            "bpsa.created ASC": "oldSort",
+            "STATE": "stateSort",
+            "m.name": "nameSort"}
 
 
 @view_config(route_name='admin-index', request_method='GET',
@@ -36,6 +42,9 @@ def admin_index(request):  # pragma: no cover
              },
             {'name': 'Message Banners',
              'uri': request.route_url('admin-add-site-messages'),
+             },
+            {'name': 'Content Status',
+             'uri': request.route_url('admin-content-status'),
              },
             ],
         }
@@ -271,3 +280,122 @@ def admin_edit_site_message_POST(request):
     args = admin_edit_site_message(request)
     args['response'] = "Message successfully Updated"
     return args
+
+
+def get_baking_statuses_sql(request):
+    args = {}
+
+    num_entries = request.GET.get('number', 100)
+    page = request.GET.get('page', 1)
+    start_entry = (int(page) - 1) * int(num_entries)
+    sort = request.GET.get('sort', 'bpsa.created DESC')
+    args[SORT_MAP[sort]] = "selected"
+    if sort == "STATE":
+        sort = 'bpsa.created DESC'
+    ident_hash_filter = request.GET.get('ident_hash', None)
+    author_filter = request.GET.get('author', None)
+
+    sql_filters = "WHERE"
+    if ident_hash_filter is not None:
+        args['ident_hash'] = ident_hash_filter
+        sql_filters += (" ident_hash(m.uuid, m.major_version, m.minor_version)"
+                        "='{}' AND ".format(ident_hash_filter))
+    if author_filter is not None:
+        sql_filters += "%(author)s=ANY(m.authors) "
+        args["author"] = author_filter
+
+    if sql_filters.endswith("AND "):
+        sql_filters = sql_filters[:-4]
+    if sql_filters == "WHERE":
+        sql_filters = ""
+
+    statement = """SELECT ident_hash(m.uuid, m.major_version, m.minor_version),
+                       m.name, m.authors, bpsa.created, bpsa.result_id::text
+                FROM document_baking_result_associations AS bpsa
+                     INNER JOIN modules AS m USING (module_ident)
+                {}
+                ORDER BY {}
+                LIMIT %(num_entries)s OFFSET %(start_entry)s
+                """.format(sql_filters, sort)
+    args.update({'sort': sort,
+                 'start_entry': start_entry,
+                 'num_entries': num_entries,
+                 'page': page})
+    return statement, args
+
+
+@view_config(route_name='admin-content-status', request_method='GET',
+             renderer='cnxpublishing.views:templates/content-status.html',
+             permission='administer')
+def admin_content_status(request):
+    settings = request.registry.settings
+    db_conn_str = settings[config.CONNECTION_STRING]
+
+    statement, args = get_baking_statuses_sql(request)
+    states = []
+    with psycopg2.connect(db_conn_str) as db_conn:
+        with db_conn.cursor() as cursor:
+            cursor.execute(statement, vars=args)
+            for row in cursor.fetchall():
+                message = ''
+                result_id = row[-1]
+                result = AsyncResult(id=result_id)
+                if result.failed():  # pragma: no cover
+                    message = result.traceback
+                states.append({
+                    'ident_hash': row[0],
+                    'title': row[1].decode('utf-8'),
+                    'authors': row[2],
+                    'created': row[3],
+                    'state': result.state,
+                    'state_message': message,
+                })
+    status_filters = request.GET.get('exculde_statuses', '').split(",")
+    all_statuses = set(["PENDING", "STARTED", "RETRY", "FAILURE", "SUCCESS"])
+    for f in (all_statuses - set(status_filters)):
+        args[f] = "checked"
+    final_states = []
+    for state in states:
+        if not(state['state'] in status_filters):
+            final_states.append(state)
+    sort = request.GET.get('sort', 'bpsa.created DESC')
+
+    if sort == "STATE":
+        sorted(final_states, key=lambda x: x['state'])
+
+    args.update({'states': final_states})
+    return args
+
+@view_config(route_name='admin-content-status-single', request_method='GET',
+             renderer='json',
+             permission='administer')
+def admin_content_status_single(request):
+    ident_hash = request.matchdict['ident_hash']
+
+    settings = request.registry.settings
+    with psycopg2.connect(settings[config.CONNECTION_STRING]) as db_conn:
+        with db_conn.cursor() as cursor:
+            cursor.execute("""SELECT ident_hash(m.uuid, m.major_version, m.minor_version),
+                               m.name, m.authors, bpsa.created, bpsa.result_id::text
+                        FROM document_baking_result_associations AS bpsa
+                             INNER JOIN modules AS m USING (module_ident)
+                        WHERE ident_hash(m.uuid, m.major_version, m.minor_version)=%s;
+                            """, vars=(ident_hash,))
+            modules = cursor.fetchall()
+            if len(modules) != 1:
+                raise httpexceptions.HTTPBadRequest(
+                    '{} is not a book'.format(ident_hash))
+            row = modules[0]
+            message = ''
+            result_id = row[-1]
+            result = AsyncResult(id=result_id)
+            if result.failed():  # pragma: no cover
+                message = result.traceback
+            return {
+                'ident_hash': row[0],
+                'title': row[1].decode('utf-8'),
+                'authors': row[2],
+                'created': str(row[3]),
+                'state': result.state,
+                'state_message': message,
+            }

--- a/cnxpublishing/views/admin.py
+++ b/cnxpublishing/views/admin.py
@@ -7,7 +7,7 @@
 # ###
 from __future__ import absolute_import
 from datetime import datetime, timedelta
-from re import compile, match
+from uuid import UUID
 
 import psycopg2
 from celery.result import AsyncResult
@@ -463,8 +463,9 @@ def admin_content_status_single(request):
     Returns a dictionary with all the past baking statuses of a single book.
     """
     uuid = request.matchdict['uuid']
-    pat = ("[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$")
-    if not compile(pat).match(uuid):
+    try:
+        UUID(uuid)
+    except ValueError:
         raise httpexceptions.HTTPBadRequest(
             '{} is not a valid uuid'.format(uuid))
 

--- a/cnxpublishing/views/templates/base.html
+++ b/cnxpublishing/views/templates/base.html
@@ -9,7 +9,7 @@
 
     <link rel="stylesheet" href="/static/css/normalize.min.css">
     <link rel="stylesheet" href="/static/css/main.css">
-
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
     <script src="/static/js/vendor/modernizr-2.8.3.min.js"></script>
     {% block head %}
     {% endblock %}

--- a/cnxpublishing/views/templates/content-status-single.html
+++ b/cnxpublishing/views/templates/content-status-single.html
@@ -6,14 +6,21 @@
   <p><b>Title:</b> {{title}}</p>
   <p><b>Authors:</b> {{authors}}</p>
   <p><b>Print Style:</b> {{print_style}}</p>
+  <p><b>CURRENT STATE:</b> {{current_state}}
+  <form method="post" id="bake_button">
+    <input hidden type="text" value="current_state">
+    <input type="submit" value="BAKE">
+  </form>
+  <br>
+  <div><b>{{response}}</b></div>
   <br><br><br>
 
   {% for state in states%}
-    <b>Ident_hash:</b> {{state.ident_hash}} &emsp;&emsp;&emsp;
+    <b>Version:</b> {{state.version}} &emsp;&emsp;&emsp;
     <b>Created:</b> {{state.created}} &emsp;&emsp;&emsp;
     <b>Recipie:</b> {{state.recipe}} &emsp;&emsp;&emsp;
     <b>State:</b> {{state.state}}<br>
-    <b>Message:</b><pre>{{state.state_message}}</pre><br>
+    <b>Message:</b><pre>{{state.state_message}}</pre>
     <br><br>
   {% endfor %}
 

--- a/cnxpublishing/views/templates/content-status-single.html
+++ b/cnxpublishing/views/templates/content-status-single.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+{% block content %}
+  <h1>Content Status</h1>
+
+  <p><b>Created:</b> {{created}}</p>
+  <p><b>Ident_hash:</b> {{ident_hash}}</p>
+  <p><b>Title:</b> {{title}}</p>
+  <p><b>Authors:</b> {{authors}}</p>
+  <p><b>State:</b> {{state}}</p>
+  <p><b>Message:</b><br><pre>{{state_message}}</pre></p>
+
+{% endblock %}

--- a/cnxpublishing/views/templates/content-status-single.html
+++ b/cnxpublishing/views/templates/content-status-single.html
@@ -1,12 +1,18 @@
 {% extends "base.html" %}
 {% block content %}
-  <h1>Content Status</h1>
+  <h1>Content Status History for single book</h1>
 
-  <p><b>Created:</b> {{created}}</p>
-  <p><b>Ident_hash:</b> {{ident_hash}}</p>
+  <p><b>uuid:</b> {{uuid}}</p>
   <p><b>Title:</b> {{title}}</p>
   <p><b>Authors:</b> {{authors}}</p>
-  <p><b>State:</b> {{state}}</p>
-  <p><b>Message:</b><br><pre>{{state_message}}</pre></p>
+  <br><br><br>
+
+  {% for state in states%}
+    <b>Ident_hash:</b> {{state.ident_hash}}<br>
+    <b>Created:</b> {{state.created}}<br>
+    <b>State:</b> {{state.state}}<br>
+    <b>Message:</b><pre>{{state.state_message}}</pre><br>
+    <br><br>
+  {% endfor %}
 
 {% endblock %}

--- a/cnxpublishing/views/templates/content-status-single.html
+++ b/cnxpublishing/views/templates/content-status-single.html
@@ -5,11 +5,13 @@
   <p><b>uuid:</b> {{uuid}}</p>
   <p><b>Title:</b> {{title}}</p>
   <p><b>Authors:</b> {{authors}}</p>
+  <p><b>Print Style:</b> {{print_style}}</p>
   <br><br><br>
 
   {% for state in states%}
-    <b>Ident_hash:</b> {{state.ident_hash}}<br>
-    <b>Created:</b> {{state.created}}<br>
+    <b>Ident_hash:</b> {{state.ident_hash}} &emsp;&emsp;&emsp;
+    <b>Created:</b> {{state.created}} &emsp;&emsp;&emsp;
+    <b>Recipie:</b> {{state.recipe}} &emsp;&emsp;&emsp;
     <b>State:</b> {{state.state}}<br>
     <b>Message:</b><pre>{{state.state_message}}</pre><br>
     <br><br>

--- a/cnxpublishing/views/templates/content-status.html
+++ b/cnxpublishing/views/templates/content-status.html
@@ -1,13 +1,13 @@
 {% extends "base.html" %}
 {% block content %}
-  <h1>Conent Status</h1>
+  <h1>Content Status</h1>
   <!-- should js go somewhere else? -->
   <script>
     function returnSubmit(e) {
       if (e.keyCode === 13) filterResults()
     }
 
-    function filterResults() {
+    function filterResults(sort="") {
       var link = "/a/content-status/?";
 
       var pageNum = document.getElementById('pageNum').value;
@@ -18,9 +18,19 @@
       var ident_hash = document.getElementById('ident_hash_filter').value;
       if (ident_hash != '') link += "ident_hash=" + ident_hash + "&";
 
-      var sort_element = document.getElementById('sort_order')
-      var sort = sort_element.options[sort_element.selectedIndex].value;
-      link += "sort=" + sort + "&";
+      // var sort_element = document.getElementById('sort_order')
+      // var sort = sort_element.options[sort_element.selectedIndex].value;
+      // link += "sort=" + sort + "&";
+      if (sort != "") {
+        // document.write(sort)
+        // document.write(window.location.href)
+        // document.write(window.location.href.includes("sort=bpsa.created%20DESC"))
+        if (window.location.href.includes("sort=" + sort + "%20ASC")) {
+              link += "sort=" + sort + " DESC&";
+        } else {
+          link += "sort=" + sort + " ASC&";
+        }
+      }
 
       var author_filter = document.getElementById('author_filter').value;
       if (author_filter != '') link += "author=" + author_filter + "&";
@@ -41,7 +51,7 @@
     }
   </script>
 
-  Filters:<br>
+  <b>Filters:</b><br>
   Status: <br>
     <label><input type="checkbox" class="status_filter" {{PENDING}} value="PENDING"> PENDING</label>&emsp;&emsp;&emsp;
     <label><input type="checkbox" class="status_filter" {{STARTED}} value="STARTED"> STARTED</label>&emsp;&emsp;&emsp;
@@ -51,40 +61,31 @@
   <br><br>Author:
     <textarea rows=1 cols=25 id="author_filter" onkeydown="returnSubmit(event)">{{author}}</textarea><br>
     </div>
-  <br>ident_hash:
+  ident_hash:
     <textarea rows=1 cols=50 id="ident_hash_filter" onkeydown="returnSubmit(event)">{{ident_hash}}</textarea><br>
   Entries Per Page:  <textarea rows=1 cols=5 id="numEntries">{{num_entries}}</textarea><br>
   Page:  <textarea rows=1 cols=5 id="pageNum">{{page}}</textarea><br>
-  <select id="sort_order">
-    <option value="bpsa.created DESC" {{newSort}}>newest first</option>
-    <option value="bpsa.created ASC" {{oldSort}}>oldest first</option>
-    <option value="STATE" {{stateSort}}>state</option>
-    <option value="m.name" {{nameSort}}>title</option>
-  </select>
   <br><br>
   <button type="button" onclick="filterResults()">Filter</button><br>
   <br><br><br>
 
   <table>
     <tr>
-      <th>Created</th>
+      <th onclick='filterResults("bpsa.created")'>* Created</th>
       <th>Ident_hash</th>
-      <th>Title</th>
-      <th>Author</th>
-      <th>State</th>
+      <th onclick='filterResults("m.name")'>* Title</th>
+      <th>Authors</th>
+      <th onclick='filterResults("STATE")'>* State</th>
       <th>Message</th>
     </tr>
     {% for state in states %}
       <tr>
         <td>{{ state.created.strftime('%Y-%m-%d %H:%M:%S') }}</td>
-        <td>
-          <!-- make this a link to another view page with more info? -->
-          <a href="/a/content-status/{{ state.ident_hash }}">{{ state.ident_hash }}</a>
-        </td>
+        <td>{{ state.ident_hash }}</td>
         <td>{{ state.title }}</td>
         <td>{{ state.authors }}</td>
-        <td>{{ state.state }}</td>
-        <td><pre>{{ state.state_message }}</pre></td>
+        <td><a href="/a/content-status/{{ state.ident_hash }}">{{ state.state }}</a></td>
+        <td>{{ state.state_message }}</td>
       </tr>
     {% endfor %}
   </table>

--- a/cnxpublishing/views/templates/content-status.html
+++ b/cnxpublishing/views/templates/content-status.html
@@ -1,95 +1,56 @@
 {% extends "base.html" %}
 {% block content %}
   <h1>Content Status</h1>
-  <!-- should js go somewhere else? -->
-  <script>
-    function returnSubmit(e) {
-      if (e.keyCode === 13) filterResults()
-    }
 
-    function filterResults(sort="") {
-      var link = "/a/content-status/?";
+  <form action="/a/content-status/" method="get">
+    <b>Filters:</b><br>
+    Status: <br>
+      <label><input type="checkbox" name="status_filter[]" {{PENDING}} value="PENDING">
+        PENDING
+        (<i class="fa fa-exclamation-triangle" style="font-size:20px;color:gold"></i>)
+      </label>&emsp;&emsp;&emsp;
+      <label><input type="checkbox" name="status_filter[]" {{STARTED}} value="STARTED">
+        STARTED
+        (<i class="fa fa-exclamation-triangle" style="font-size:20px;color:gold"></i>)
+      </label>&emsp;&emsp;&emsp;
+      <label><input type="checkbox" name="status_filter[]" {{RETRY}} value="RETRY">
+        RETRY
+        (<i class="fa fa-close" style="font-size:20px;color:red"></i>)
+      </label>&emsp;&emsp;&emsp;
+      <label><input type="checkbox" name="status_filter[]" {{FAILURE}} value="FAILURE">
+        FAILURE
+        (<i class="fa fa-close" style="font-size:20px;color:red"></i>)
+      </label>&emsp;&emsp;&emsp;
+      <label><input type="checkbox" name="status_filter[]" {{SUCCESS}} value="SUCCESS">
+        SUCCESS
+        (<i class="fa fa-check-square" style="font-size:20px;color:limeGreen"></i>)
+      </label>
+    <br><br>Author:
+      <input type="text" name="author" value={{author}}><br>
+    ident_hash:
+      <input type="text" name="ident_hash" value={{ident_hash}}><br>
+    Entries Per Page:  <input type="number" min="1" name="number" value={{num_entries}}><br>
+    Page:  <input type="number" min="1" name="page" value={{page}}><br>
+    Sort Order?
+    <select name="sort">
+      <option value="bpsa.created DESC" {{newSort}}>newest first</option>
+      <option value="bpsa.created ASC" {{oldSort}}>oldest first</option>
+      <option value="STATE" {{stateSort}}>state</option>
+      <option value="m.name" {{nameSort}}>title</option>
+    </select>
+    <br><br>
+    <input type="submit" value="Filter"><br>
+  </form>
 
-      var pageNum = document.getElementById('pageNum').value;
-      var numEntries = document.getElementById('numEntries').value;
-      if (pageNum != '') link += "page=" + pageNum + "&";
-      if (numEntries != '') link += "number=" + numEntries + "&";
-
-      var ident_hash = document.getElementById('ident_hash_filter').value;
-      if (ident_hash != '') link += "ident_hash=" + ident_hash + "&";
-
-      // var sort_element = document.getElementById('sort_order')
-      // var sort = sort_element.options[sort_element.selectedIndex].value;
-      // link += "sort=" + sort + "&";
-      if (sort != "") {
-        // document.write(sort)
-        // document.write(window.location.href)
-        // document.write(window.location.href.includes("sort=bpsa.created%20DESC"))
-        if (window.location.href.includes("sort=" + sort + "%20ASC")) {
-              link += "sort=" + sort + " DESC&";
-        } else {
-          link += "sort=" + sort + " ASC&";
-        }
-      }
-
-      var author_filter = document.getElementById('author_filter').value;
-      if (author_filter != '') link += "author=" + author_filter + "&";
-
-      var authors = document.getElementById("author_filter")
-      for(var i = 0; i < authors.length; i++) {
-        if (authors[i].value != '') link += "author" + i + "=" + authors[i].value + "&";
-      }
-
-      var statuses = document.getElementsByClassName("status_filter")
-      var excluded = []
-      for(var i = 0; i < statuses.length; i++) {
-        if (! statuses[i].checked) excluded.push(statuses[i].value);
-      }
-      if (excluded.length > 0) link += "exculde_statuses=" + excluded.join(",")
-
-      window.location.href = link;
-    }
-  </script>
-
-  <b>Filters:</b><br>
-  Status: <br>
-    <label><input type="checkbox" class="status_filter" {{PENDING}} value="PENDING">
-      PENDING
-      (<i class="fa fa-exclamation-triangle" style="font-size:20px;color:gold"></i>)
-    </label>&emsp;&emsp;&emsp;
-    <label><input type="checkbox" class="status_filter" {{STARTED}} value="STARTED">
-      STARTED
-      (<i class="fa fa-exclamation-triangle" style="font-size:20px;color:gold"></i>)
-    </label>&emsp;&emsp;&emsp;
-    <label><input type="checkbox" class="status_filter" {{RETRY}} value="RETRY">
-      RETRY
-      (<i class="fa fa-close" style="font-size:20px;color:red"></i>)
-    </label>&emsp;&emsp;&emsp;
-    <label><input type="checkbox" class="status_filter" {{FAILURE}} value="FAILURE">
-      FAILURE
-      (<i class="fa fa-close" style="font-size:20px;color:red"></i>)
-    </label>&emsp;&emsp;&emsp;
-    <label><input type="checkbox" class="status_filter" {{SUCCESS}} value="SUCCESS">
-      SUCCESS
-      (<i class="fa fa-check-square" style="font-size:20px;color:limeGreen"></i>)
-    </label>
-  <br><br>Author:
-    <textarea rows=1 cols=25 id="author_filter" onkeydown="returnSubmit(event)">{{author}}</textarea><br>
-  ident_hash:
-    <textarea rows=1 cols=50 id="ident_hash_filter" onkeydown="returnSubmit(event)">{{ident_hash}}</textarea><br>
-  Entries Per Page:  <textarea rows=1 cols=5 id="numEntries">{{num_entries}}</textarea><br>
-  Page:  <textarea rows=1 cols=5 id="pageNum">{{page}}</textarea><br>
-  <br><br>
-  <button type="button" onclick="filterResults()">Filter</button><br>
   <br><br><br>
 
   <table>
     <tr>
-      <th onclick='filterResults("bpsa.created")'>Created<i class="{{sort_created}}"></i></th>
+      <th>Created</th>
       <th>Ident_hash</th>
-      <th onclick='filterResults("m.name")'>Title<i class="{{sort_name}}"></i></th>
+      <th>Title</th>
       <th>Authors</th>
-      <th onclick='filterResults("STATE")'>State<i class="{{sort_state}}"></i></th>
+      <th>State</th>
       <th>Message</th>
     </tr>
     {% for state in states %}

--- a/cnxpublishing/views/templates/content-status.html
+++ b/cnxpublishing/views/templates/content-status.html
@@ -2,6 +2,24 @@
 {% block content %}
   <h1>Content Status</h1>
 
+  <script>
+    function sortBooks(col) {
+      var new_link = "";
+      var current_url = window.location.href;
+      if (current_url.includes("sort=")) {
+        new_sort = current_url.includes("sort=" + col + "%20ASC")
+              ? "sort=" + col + " DESC"
+              : "sort=" + col + " ASC";
+        new_link = current_url.replace(/sort=[^&]*/, new_sort);
+      } else if (current_url.includes("/?")) { // no sort filter
+        new_link = current_url + "&sort=" + col + " ASC";
+      } else {  // no filters of any kind
+        new_link = current_url + "?sort=" + col + " ASC";
+      }
+      window.location.href = new_link;
+    }
+  </script>
+
   <form action="/a/content-status/" method="get">
     <b>Filters:</b><br>
     Status: <br>
@@ -31,13 +49,6 @@
       <input type="text" name="ident_hash" value={{ident_hash}}><br>
     Entries Per Page:  <input type="number" min="1" name="number" value={{num_entries}}><br>
     Page:  <input type="number" min="1" name="page" value={{page}}><br>
-    Sort Order?
-    <select name="sort">
-      <option value="bpsa.created DESC" {{newSort}}>newest first</option>
-      <option value="bpsa.created ASC" {{oldSort}}>oldest first</option>
-      <option value="STATE" {{stateSort}}>state</option>
-      <option value="m.name" {{nameSort}}>title</option>
-    </select>
     <br><br>
     <input type="submit" value="Filter"><br>
   </form>
@@ -46,11 +57,11 @@
 
   <table>
     <tr>
-      <th>Created</th>
+      <th onclick='sortBooks("bpsa.created")'>Created<i class="{{sort_created}}"></i></th>
       <th>Ident_hash</th>
-      <th>Title</th>
+      <th onclick='sortBooks("m.name")'>Title<i class="{{sort_name}}"></i></th>
       <th>Authors</th>
-      <th>State</th>
+      <th onclick='sortBooks("STATE")'>State<i class="{{sort_state}}"></i></th>
       <th>Message</th>
     </tr>
     {% for state in states %}

--- a/cnxpublishing/views/templates/content-status.html
+++ b/cnxpublishing/views/templates/content-status.html
@@ -85,11 +85,11 @@
 
   <table>
     <tr>
-      <th onclick='filterResults("bpsa.created")'>* Created</th>
+      <th onclick='filterResults("bpsa.created")'><i class="{{sort_created}}"></i>Created</th>
       <th>Ident_hash</th>
-      <th onclick='filterResults("m.name")'>* Title</th>
+      <th onclick='filterResults("m.name")'><i class="{{sort_name}}"></i> Title</th>
       <th>Authors</th>
-      <th onclick='filterResults("STATE")'>* State</th>
+      <th onclick='filterResults("STATE")'><i class="{{sort_state}}"></i> State</th>
       <th>Message</th>
     </tr>
     {% for state in states %}

--- a/cnxpublishing/views/templates/content-status.html
+++ b/cnxpublishing/views/templates/content-status.html
@@ -1,25 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
   <h1>Content Status</h1>
-
-  <script>
-    function sortBooks(col) {
-      var new_link = "";
-      var current_url = window.location.href;
-      if (current_url.includes("sort=")) {
-        new_sort = current_url.includes("sort=" + col + "%20ASC")
-              ? "sort=" + col + " DESC"
-              : "sort=" + col + " ASC";
-        new_link = current_url.replace(/sort=[^&]*/, new_sort);
-      } else if (current_url.includes("/?")) { // no sort filter
-        new_link = current_url + "&sort=" + col + " ASC";
-      } else {  // no filters of any kind
-        new_link = current_url + "?sort=" + col + " ASC";
-      }
-      window.location.href = new_link;
-    }
-  </script>
-
   <form action="/a/content-status/" method="get">
     <b>Filters:</b><br>
     Status: <br>
@@ -78,4 +59,21 @@
       </tr>
     {% endfor %}
   </table>
+{% endblock %}
+{% block script %}
+  function sortBooks(col) {
+    var new_link = "";
+    var current_url = window.location.href;
+    if (current_url.includes("sort=")) {
+      new_sort = current_url.includes("sort=" + col + "%20ASC")
+            ? "sort=" + col + " DESC"
+            : "sort=" + col + " ASC";
+      new_link = current_url.replace(/sort=[^&]*/, new_sort);
+    } else if (current_url.includes("/?")) { // no sort filter
+      new_link = current_url + "&sort=" + col + " ASC";
+    } else {  // no filters of any kind
+      new_link = current_url + "?sort=" + col + " ASC";
+    }
+    window.location.href = new_link;
+  }
 {% endblock %}

--- a/cnxpublishing/views/templates/content-status.html
+++ b/cnxpublishing/views/templates/content-status.html
@@ -52,7 +52,7 @@
       <tr>
         <td>{{ state.created.strftime('%Y-%m-%d %H:%M:%S') }}</td>
         <td>
-          <a href="/a/content-status/{{ state.uuid }}">{{ state.title }}</a>
+          <a href="{{ state.status_link }}">{{ state.title }}</a>
         </td>
         <td>{{ state.authors }}</td>
         <td>
@@ -61,7 +61,7 @@
         <td>{{ state.print_style }}</td>
         <td>{{ state.recipie }}</td>
         <td>
-          <a href='/contents/{{ state.uuid }}'>{{ state.uuid }}</a>
+          <a href='{{ state.content_link }}'>{{ state.uuid }}</a>
         </td>
         <td>{{ state.state_message }}</td>
       </tr>

--- a/cnxpublishing/views/templates/content-status.html
+++ b/cnxpublishing/views/templates/content-status.html
@@ -53,14 +53,28 @@
 
   <b>Filters:</b><br>
   Status: <br>
-    <label><input type="checkbox" class="status_filter" {{PENDING}} value="PENDING"> PENDING</label>&emsp;&emsp;&emsp;
-    <label><input type="checkbox" class="status_filter" {{STARTED}} value="STARTED"> STARTED</label>&emsp;&emsp;&emsp;
-    <label><input type="checkbox" class="status_filter" {{RETRY}} value="RETRY"> RETRY</label>&emsp;&emsp;&emsp;
-    <label><input type="checkbox" class="status_filter" {{FAILURE}} value="FAILURE"> FAILURE</label>&emsp;&emsp;&emsp;
-    <label><input type="checkbox" class="status_filter" {{SUCCESS}} value="SUCCESS"> SUCCESS</label>
+    <label><input type="checkbox" class="status_filter" {{PENDING}} value="PENDING">
+      PENDING
+      (<i class="fa fa-exclamation-triangle" style="font-size:20px;color:gold"></i>)
+    </label>&emsp;&emsp;&emsp;
+    <label><input type="checkbox" class="status_filter" {{STARTED}} value="STARTED">
+      STARTED
+      (<i class="fa fa-exclamation-triangle" style="font-size:20px;color:gold"></i>)
+    </label>&emsp;&emsp;&emsp;
+    <label><input type="checkbox" class="status_filter" {{RETRY}} value="RETRY">
+      RETRY
+      (<i class="fa fa-close" style="font-size:20px;color:red"></i>)
+    </label>&emsp;&emsp;&emsp;
+    <label><input type="checkbox" class="status_filter" {{FAILURE}} value="FAILURE">
+      FAILURE
+      (<i class="fa fa-close" style="font-size:20px;color:red"></i>)
+    </label>&emsp;&emsp;&emsp;
+    <label><input type="checkbox" class="status_filter" {{SUCCESS}} value="SUCCESS">
+      SUCCESS
+      (<i class="fa fa-check-square" style="font-size:20px;color:limeGreen"></i>)
+    </label>
   <br><br>Author:
     <textarea rows=1 cols=25 id="author_filter" onkeydown="returnSubmit(event)">{{author}}</textarea><br>
-    </div>
   ident_hash:
     <textarea rows=1 cols=50 id="ident_hash_filter" onkeydown="returnSubmit(event)">{{ident_hash}}</textarea><br>
   Entries Per Page:  <textarea rows=1 cols=5 id="numEntries">{{num_entries}}</textarea><br>
@@ -84,7 +98,10 @@
         <td>{{ state.ident_hash }}</td>
         <td>{{ state.title }}</td>
         <td>{{ state.authors }}</td>
-        <td><a href="/a/content-status/{{ state.ident_hash }}">{{ state.state }}</a></td>
+        <td>
+          <i class="{{state.state_icon}}" style="{{state.state_icon_style}}"></i>
+          <a href="/a/content-status/{{ state.ident_hash }}">{{ state.state }}</a>
+        </td>
         <td>{{ state.state_message }}</td>
       </tr>
     {% endfor %}

--- a/cnxpublishing/views/templates/content-status.html
+++ b/cnxpublishing/views/templates/content-status.html
@@ -1,0 +1,91 @@
+{% extends "base.html" %}
+{% block content %}
+  <h1>Conent Status</h1>
+  <!-- should js go somewhere else? -->
+  <script>
+    function returnSubmit(e) {
+      if (e.keyCode === 13) filterResults()
+    }
+
+    function filterResults() {
+      var link = "/a/content-status/?";
+
+      var pageNum = document.getElementById('pageNum').value;
+      var numEntries = document.getElementById('numEntries').value;
+      if (pageNum != '') link += "page=" + pageNum + "&";
+      if (numEntries != '') link += "number=" + numEntries + "&";
+
+      var ident_hash = document.getElementById('ident_hash_filter').value;
+      if (ident_hash != '') link += "ident_hash=" + ident_hash + "&";
+
+      var sort_element = document.getElementById('sort_order')
+      var sort = sort_element.options[sort_element.selectedIndex].value;
+      link += "sort=" + sort + "&";
+
+      var author_filter = document.getElementById('author_filter').value;
+      if (author_filter != '') link += "author=" + author_filter + "&";
+
+      var authors = document.getElementById("author_filter")
+      for(var i = 0; i < authors.length; i++) {
+        if (authors[i].value != '') link += "author" + i + "=" + authors[i].value + "&";
+      }
+
+      var statuses = document.getElementsByClassName("status_filter")
+      var excluded = []
+      for(var i = 0; i < statuses.length; i++) {
+        if (! statuses[i].checked) excluded.push(statuses[i].value);
+      }
+      if (excluded.length > 0) link += "exculde_statuses=" + excluded.join(",")
+
+      window.location.href = link;
+    }
+  </script>
+
+  Filters:<br>
+  Status: <br>
+    <label><input type="checkbox" class="status_filter" {{PENDING}} value="PENDING"> PENDING</label>&emsp;&emsp;&emsp;
+    <label><input type="checkbox" class="status_filter" {{STARTED}} value="STARTED"> STARTED</label>&emsp;&emsp;&emsp;
+    <label><input type="checkbox" class="status_filter" {{RETRY}} value="RETRY"> RETRY</label>&emsp;&emsp;&emsp;
+    <label><input type="checkbox" class="status_filter" {{FAILURE}} value="FAILURE"> FAILURE</label>&emsp;&emsp;&emsp;
+    <label><input type="checkbox" class="status_filter" {{SUCCESS}} value="SUCCESS"> SUCCESS</label>
+  <br><br>Author:
+    <textarea rows=1 cols=25 id="author_filter" onkeydown="returnSubmit(event)">{{author}}</textarea><br>
+    </div>
+  <br>ident_hash:
+    <textarea rows=1 cols=50 id="ident_hash_filter" onkeydown="returnSubmit(event)">{{ident_hash}}</textarea><br>
+  Entries Per Page:  <textarea rows=1 cols=5 id="numEntries">{{num_entries}}</textarea><br>
+  Page:  <textarea rows=1 cols=5 id="pageNum">{{page}}</textarea><br>
+  <select id="sort_order">
+    <option value="bpsa.created DESC" {{newSort}}>newest first</option>
+    <option value="bpsa.created ASC" {{oldSort}}>oldest first</option>
+    <option value="STATE" {{stateSort}}>state</option>
+    <option value="m.name" {{nameSort}}>title</option>
+  </select>
+  <br><br>
+  <button type="button" onclick="filterResults()">Filter</button><br>
+  <br><br><br>
+
+  <table>
+    <tr>
+      <th>Created</th>
+      <th>Ident_hash</th>
+      <th>Title</th>
+      <th>Author</th>
+      <th>State</th>
+      <th>Message</th>
+    </tr>
+    {% for state in states %}
+      <tr>
+        <td>{{ state.created.strftime('%Y-%m-%d %H:%M:%S') }}</td>
+        <td>
+          <!-- make this a link to another view page with more info? -->
+          <a href="/a/content-status/{{ state.ident_hash }}">{{ state.ident_hash }}</a>
+        </td>
+        <td>{{ state.title }}</td>
+        <td>{{ state.authors }}</td>
+        <td>{{ state.state }}</td>
+        <td><pre>{{ state.state_message }}</pre></td>
+      </tr>
+    {% endfor %}
+  </table>
+{% endblock %}

--- a/cnxpublishing/views/templates/content-status.html
+++ b/cnxpublishing/views/templates/content-status.html
@@ -85,11 +85,11 @@
 
   <table>
     <tr>
-      <th onclick='filterResults("bpsa.created")'><i class="{{sort_created}}"></i>Created</th>
+      <th onclick='filterResults("bpsa.created")'>Created<i class="{{sort_created}}"></i></th>
       <th>Ident_hash</th>
-      <th onclick='filterResults("m.name")'><i class="{{sort_name}}"></i> Title</th>
+      <th onclick='filterResults("m.name")'>Title<i class="{{sort_name}}"></i></th>
       <th>Authors</th>
-      <th onclick='filterResults("STATE")'><i class="{{sort_state}}"></i> State</th>
+      <th onclick='filterResults("STATE")'>State<i class="{{sort_state}}"></i></th>
       <th>Message</th>
     </tr>
     {% for state in states %}

--- a/cnxpublishing/views/templates/content-status.html
+++ b/cnxpublishing/views/templates/content-status.html
@@ -61,7 +61,7 @@
         <td>{{ state.print_style }}</td>
         <td>{{ state.recipie }}</td>
         <td>
-          <a href='{{ state.content_link }}'>{{ state.uuid }}</a>
+          <a href='{{ state.content_link }}'>{{ state.content_link }}</a>
         </td>
         <td>{{ state.state_message }}</td>
       </tr>

--- a/cnxpublishing/views/templates/content-status.html
+++ b/cnxpublishing/views/templates/content-status.html
@@ -26,8 +26,8 @@
       </label>
     <br><br>Author:
       <input type="text" name="author" value={{author}}><br>
-    ident_hash:
-      <input type="text" name="ident_hash" value={{ident_hash}}><br>
+    uuid:
+      <input type="text" name="uuid" value={{uuid}}><br>
     Entries Per Page:  <input type="number" min="1" name="number" value={{num_entries}}><br>
     Page:  <input type="number" min="1" name="page" value={{page}}><br>
     <br><br>
@@ -53,7 +53,7 @@
         <td>{{ state.authors }}</td>
         <td>
           <i class="{{state.state_icon}}" style="{{state.state_icon_style}}"></i>
-          <a href="/a/content-status/{{ state.ident_hash }}">{{ state.state }}</a>
+          <a href="/a/content-status/{{ state.uuid }}">{{ state.state }}</a>
         </td>
         <td>{{ state.state_message }}</td>
       </tr>

--- a/cnxpublishing/views/templates/content-status.html
+++ b/cnxpublishing/views/templates/content-status.html
@@ -4,23 +4,23 @@
   <form action="/a/content-status/" method="get">
     <b>Filters:</b><br>
     Status: <br>
-      <label><input type="checkbox" name="status_filter[]" {{PENDING}} value="PENDING">
+      <label><input type="checkbox" name="status_filter" {{PENDING}} value="PENDING">
         PENDING
         (<i class="fa fa-exclamation-triangle" style="font-size:20px;color:gold"></i>)
       </label>&emsp;&emsp;&emsp;
-      <label><input type="checkbox" name="status_filter[]" {{STARTED}} value="STARTED">
+      <label><input type="checkbox" name="status_filter" {{STARTED}} value="STARTED">
         STARTED
         (<i class="fa fa-exclamation-triangle" style="font-size:20px;color:gold"></i>)
       </label>&emsp;&emsp;&emsp;
-      <label><input type="checkbox" name="status_filter[]" {{RETRY}} value="RETRY">
+      <label><input type="checkbox" name="status_filter" {{RETRY}} value="RETRY">
         RETRY
         (<i class="fa fa-close" style="font-size:20px;color:red"></i>)
       </label>&emsp;&emsp;&emsp;
-      <label><input type="checkbox" name="status_filter[]" {{FAILURE}} value="FAILURE">
+      <label><input type="checkbox" name="status_filter" {{FAILURE}} value="FAILURE">
         FAILURE
         (<i class="fa fa-close" style="font-size:20px;color:red"></i>)
       </label>&emsp;&emsp;&emsp;
-      <label><input type="checkbox" name="status_filter[]" {{SUCCESS}} value="SUCCESS">
+      <label><input type="checkbox" name="status_filter" {{SUCCESS}} value="SUCCESS">
         SUCCESS
         (<i class="fa fa-check-square" style="font-size:20px;color:limeGreen"></i>)
       </label>
@@ -30,30 +30,38 @@
       <input type="text" name="uuid" value={{uuid}}><br>
     Entries Per Page:  <input type="number" min="1" name="number" value={{num_entries}}><br>
     Page:  <input type="number" min="1" name="page" value={{page}}><br>
-    <br><br>
+    <br>
     <input type="submit" value="Filter"><br>
   </form>
-
+  <br><br>
+  Showing {{start_entry + 1}} - {{start_entry + num_entries}} of {{total_entries}}
   <br><br><br>
 
   <table>
     <tr>
       <th onclick='sortBooks("bpsa.created")'>Created<i class="{{sort_created}}"></i></th>
-      <th>Ident_hash</th>
       <th onclick='sortBooks("m.name")'>Title<i class="{{sort_name}}"></i></th>
       <th>Authors</th>
       <th onclick='sortBooks("STATE")'>State<i class="{{sort_state}}"></i></th>
+      <th>Print Style</th>
+      <th>Recipe</th>
+      <th>Link to book</th>
       <th>Message</th>
     </tr>
     {% for state in states %}
       <tr>
         <td>{{ state.created.strftime('%Y-%m-%d %H:%M:%S') }}</td>
-        <td>{{ state.ident_hash }}</td>
-        <td>{{ state.title }}</td>
+        <td>
+          <a href="/a/content-status/{{ state.uuid }}">{{ state.title }}</a>
+        </td>
         <td>{{ state.authors }}</td>
         <td>
-          <i class="{{state.state_icon}}" style="{{state.state_icon_style}}"></i>
-          <a href="/a/content-status/{{ state.uuid }}">{{ state.state }}</a>
+          <i class="{{state.state_icon}}" style="{{state.state_icon_style}}"></i>{{ state.state }}
+        </td>
+        <td>{{ state.print_style }}</td>
+        <td>{{ state.recipie }}</td>
+        <td>
+          <a href='{{ state.link }}'>{{ state.ident_hash }}</a>
         </td>
         <td>{{ state.state_message }}</td>
       </tr>

--- a/cnxpublishing/views/templates/content-status.html
+++ b/cnxpublishing/views/templates/content-status.html
@@ -4,23 +4,23 @@
   <form action="/a/content-status/" method="get">
     <b>Filters:</b><br>
     Status: <br>
-      <label><input type="checkbox" name="status_filter" {{PENDING}} value="PENDING">
+      <label><input type="checkbox" name="pending_filter" {{PENDING}} value="PENDING">
         PENDING
         (<i class="fa fa-exclamation-triangle" style="font-size:20px;color:gold"></i>)
       </label>&emsp;&emsp;&emsp;
-      <label><input type="checkbox" name="status_filter" {{STARTED}} value="STARTED">
+      <label><input type="checkbox" name="started_filter" {{STARTED}} value="STARTED">
         STARTED
         (<i class="fa fa-exclamation-triangle" style="font-size:20px;color:gold"></i>)
       </label>&emsp;&emsp;&emsp;
-      <label><input type="checkbox" name="status_filter" {{RETRY}} value="RETRY">
+      <label><input type="checkbox" name="retry_filter" {{RETRY}} value="RETRY">
         RETRY
         (<i class="fa fa-close" style="font-size:20px;color:red"></i>)
       </label>&emsp;&emsp;&emsp;
-      <label><input type="checkbox" name="status_filter" {{FAILURE}} value="FAILURE">
+      <label><input type="checkbox" name="failure_filter" {{FAILURE}} value="FAILURE">
         FAILURE
         (<i class="fa fa-close" style="font-size:20px;color:red"></i>)
       </label>&emsp;&emsp;&emsp;
-      <label><input type="checkbox" name="status_filter" {{SUCCESS}} value="SUCCESS">
+      <label><input type="checkbox" name="success_filter" {{SUCCESS}} value="SUCCESS">
         SUCCESS
         (<i class="fa fa-check-square" style="font-size:20px;color:limeGreen"></i>)
       </label>
@@ -61,7 +61,7 @@
         <td>{{ state.print_style }}</td>
         <td>{{ state.recipie }}</td>
         <td>
-          <a href='{{ state.link }}'>{{ state.ident_hash }}</a>
+          <a href='/contents/{{ state.uuid }}'>{{ state.uuid }}</a>
         </td>
         <td>{{ state.state_message }}</td>
       </tr>


### PR DESCRIPTION
a view of the books that are in the process of baking
books can be filtered by status, author, and ident_hash
the page number and entries per page can be set

detailed traceback available by a link to individual book page (linked on table)
EDIT: this page shows the history of the state/traceback for all versions of that book (all books with that same uuid) with the most recent on top and older ones further down the page. There is also a button to bake the book on this page. It only work if the book has not already been successfully baked for the most recent content/recipe.

When filtering it just changes the query in the url and reloads page to the new url by getting the information from the fields using javascript. Also there is a tiny bit of styling using font-awesome to add the icons from the napkin notes, should I pull that out into a css file?

The unit tests are a little funky though. They all work, but they have to be run one at a time. And there are skips in front of each of them now because celery gets confused about adding stuff to the database and reseting it...

EDIT:
changed javascript to an html element `<form method="get">` instead of using javascript to get the values from elements. But undid the sort to click on table header and use a form element to choose sort instead so that there is now only javascript for the sorting of the columns