### PR TITLE
use print-style to select recipe and fallback

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,14 +37,14 @@ before_install:
   # Install cnx-easybake
   - pip install git+https://github.com/Connexions/cnx-easybake.git#egg=cnx-easybake
   # * Install cnx-epub
-  - git clone https://github.com/Connexions/cnx-epub.git
+  - git clone --branch print-style-recipes https://github.com/Connexions/cnx-epub.git
   - cd cnx-epub && python setup.py install && cd ..
 
   # * Install cnx-archive
   - git clone https://github.com/Connexions/cnx-archive.git
   - cd cnx-archive && python setup.py install && cd ..
   # * Install cnx-db
-  - git clone https://github.com/Connexions/cnx-db.git
+  - git clone --branch print-style-recipes https://github.com/Connexions/cnx-db.git
   - cd cnx-db && python setup.py install && cd ..
   # Install the coverage utility and codecov reporting utility
   - pip install coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,14 +37,14 @@ before_install:
   # Install cnx-easybake
   - pip install git+https://github.com/Connexions/cnx-easybake.git#egg=cnx-easybake
   # * Install cnx-epub
-  - git clone --branch print-style-recipes https://github.com/Connexions/cnx-epub.git
+  - git clone https://github.com/Connexions/cnx-epub.git
   - cd cnx-epub && python setup.py install && cd ..
 
   # * Install cnx-archive
   - git clone https://github.com/Connexions/cnx-archive.git
   - cd cnx-archive && python setup.py install && cd ..
   # * Install cnx-db
-  - git clone --branch print-style-recipes https://github.com/Connexions/cnx-db.git
+  - git clone https://github.com/Connexions/cnx-db.git
   - cd cnx-db && python setup.py install && cd ..
   # Install the coverage utility and codecov reporting utility
   - pip install coverage

--- a/cnxpublishing/bake.py
+++ b/cnxpublishing/bake.py
@@ -51,13 +51,13 @@ def _formatter_callback_factory():  # pragma: no cover
 
 
 @with_db_cursor
-def bake(binder, publisher, message, cursor):
+def bake(binder, recipe, publisher, message, cursor):
     """Given a `Binder` as `binder`, bake the contents and
     persist those changes alongside the published content.
 
     """
     includes = _formatter_callback_factory()
-    binder = collate_models(binder, ruleset="ruleset.css", includes=includes)
+    binder = collate_models(binder, ruleset=recipe, includes=includes)
 
     def flatten_filter(model):
         return (isinstance(model, cnxepub.CompositeDocument) or

--- a/cnxpublishing/db.py
+++ b/cnxpublishing/db.py
@@ -1425,7 +1425,8 @@ INSERT INTO post_publications
   VALUES (%s, %s, %s)""", (module_ident, state_name, state_message))
 
 
-def update_module_state(cursor, module_ident, state_name, recipe):  # pragma: no cover
+def update_module_state(cursor, module_ident,
+                        state_name, recipe):  # pragma: no cover
     """This updates the module's state in the database."""
     cursor.execute("""\
 UPDATE modules

--- a/cnxpublishing/db.py
+++ b/cnxpublishing/db.py
@@ -323,7 +323,7 @@ def _validate_derived_from(cursor, model):
                                          original_exception=exc)
     # Is the ident-hash a valid pointer?
     args = [uuid_]
-    table = 'latest_modules'
+    table = 'modules'
     version_condition = ''
     if version != (None, None,):
         args.extend(version)
@@ -759,7 +759,7 @@ def is_revision_publication(publication_id, cursor):
     existing piece of content.
     """
     cursor.execute("""\
-SELECT 't'::boolean FROM latest_modules
+SELECT 't'::boolean FROM modules
 WHERE uuid IN (SELECT uuid
                FROM pending_documents
                WHERE publication_id = %s)
@@ -1425,13 +1425,13 @@ INSERT INTO post_publications
   VALUES (%s, %s, %s)""", (module_ident, state_name, state_message))
 
 
-def update_module_state(cursor, module_ident, state_name):  # pragma: no cover
+def update_module_state(cursor, module_ident, state_name, recipe):  # pragma: no cover
     """This updates the module's state in the database."""
     cursor.execute("""\
 UPDATE modules
 SET stateid = (
     SELECT stateid FROM modulestates WHERE statename = %s
-) WHERE module_ident = %s""", (state_name, module_ident))
+), recipe = %s WHERE module_ident = %s""", (state_name, recipe, module_ident))
 
 
 __all__ = (

--- a/cnxpublishing/subscribers.py
+++ b/cnxpublishing/subscribers.py
@@ -63,6 +63,9 @@ def _get_recipes(module_ident, cursor):
                                      LEFT JOIN module_files mf
                                          ON m.module_ident = mf.module_ident
                                          AND m.print_style = mf.filename
+                                     LEFT JOIN module_files mf2
+                                         ON m.module_ident = mf2.module_ident
+                                         AND mf2.filename = 'ruleset.css'
                                      LEFT JOIN latest_modules lm
                                          ON m.uuid = lm.uuid
                       WHERE m.module_ident = %s""", (module_ident,))

--- a/cnxpublishing/tests/test_bake.py
+++ b/cnxpublishing/tests/test_bake.py
@@ -72,9 +72,11 @@ WHERE
             binder_model.append(composite_section)
             return binder_model
 
+        fake_recipe = 'div::after { content: "test" }'
+
         with mock.patch('cnxpublishing.bake.collate_models') as mock_collate:
             mock_collate.side_effect = cnxepub_collate
-            errors = self.target(binder, publisher, msg)
+            errors = self.target(binder, fake_recipe, publisher, msg)
 
         # Ensure the output of the errors.
         self.assertEqual(errors, [])
@@ -160,7 +162,8 @@ WHERE
         with mock.patch('cnxpublishing.bake.collate_models') as mock_collate:
             mock_collate.side_effect = cnxepub_collate
             from cnxpublishing.bake import bake
-            errors = bake(binder, publisher, msg, cursor=cursor)
+            fake_recipe = 'div::after { content: "test" }'
+            errors = bake(binder, fake_recipe, publisher, msg, cursor=cursor)
 
         self.ident_hash = binder.ident_hash
         self.composite_ident_hash = composite_doc.ident_hash

--- a/cnxpublishing/tests/views/test_publishing.py
+++ b/cnxpublishing/tests/views/test_publishing.py
@@ -1415,8 +1415,8 @@ class BakeContentTestCase(BaseFunctionalViewTestCase):
 
         with mock.patch('cnxpublishing.bake.collate_models') as mock_collate:
             mock_collate.side_effect = _collate
-
-            bake(binder, publisher, message, cursor=cursor)
+            fake_recipe = 'div::after {cotents: "test"}'
+            bake(binder, publisher, fake_recipe, message, cursor=cursor)
             self.assertEqual(1, mock_collate.call_count)
 
         # Ensure the tree as been stamped.


### PR DESCRIPTION
Alter the method of selecting recipe for post publication baking. Now depends on print-style of book. Provide fallback mechanism of using last-most-recently successful recipe.

Depends on Connexions/cnx-db#35 and Connexions/cnx-epub#121