### PR TITLE
Print style view

### DIFF
--- a/.travis-compose.yml
+++ b/.travis-compose.yml
@@ -1,7 +1,7 @@
 version: "2"
 services:
   db:
-    build: https://github.com/Connexions/cnx-db.git
+    build: https://github.com/Connexions/cnx-db.git#all-current-view
     ports:
       - "5432:5432"
     environment:

--- a/.travis-compose.yml
+++ b/.travis-compose.yml
@@ -1,0 +1,9 @@
+version: "2"
+services:
+  db:
+    build: https://github.com/Connexions/cnx-db.git
+    ports:
+      - "5432:5432"
+    environment:
+      - DB_USER=cnxarchive
+      - DB_NAME=cnxarchive-testing

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_install:
   # * Install cnx-epub
   - pip install git+https://github.com/Connexions/cnx-epub.git#egg=cnx-epub
   # * Install cnx-db
-  - pip install git+https://github.com/Connexions/cnx-db.git#egg=cnx-db
+  - pip install git+https://github.com/Connexions/cnx-db.git@all-current-view#egg=cnx-db
   # * Install cnx-archive
   - pip install git+https://github.com/Connexions/cnx-archive.git#egg=cnx-archive
   # Install the coverage utility and codecov reporting utility

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
-dist: precise
+dist: trusty
+sudo: required
 language: python
 # Note, /usr/bin/python is used because we must install to the system python
 # in order to make the package available to the plpython Postgres extension.
 python:
   - "2.7"
-addons:
-  postgresql: "9.4"
 services:
   - rabbitmq
+  - docker
 before_install:
   - pip install pep8
   - pep8 --exclude=tests *.py cnxpublishing/
@@ -16,21 +16,18 @@ before_install:
   - sudo apt-get update
   # remove zope.interface installed from aptitude
   - sudo apt-get purge python-zope.interface
-  # Install the 'plpython' extension language
+
+  # Stop local postgres
+  - sudo service postgresql stop
+
+  # Create cnx-db docker image
+  - docker-compose -f .travis-compose.yml up -d
 
   # Installation for cnx-archive:
-  # * Install the 'plpython' extension language
-  - sudo apt-get install postgresql-plpython-9.4
-  # * Install the 'plxslt' extension language
-  - sudo apt-get install libxml2-dev libxslt-dev postgresql-server-dev-9.4
-  - git clone https://github.com/petere/plxslt.git
-  - cd plxslt && sudo make && sudo make install && cd ..
   # * Install cnx-query-grammar
-  - git clone https://github.com/Connexions/cnx-query-grammar.git
-  - cd cnx-query-grammar && python setup.py install && cd ..
+  - pip install git+https://github.com/Connexions/cnx-query-grammar.git#egg=cnx-query-grammar
   # * Install rhaptos.cnxmlutils
-  - git clone https://github.com/Connexions/rhaptos.cnxmlutils.git
-  - cd rhaptos.cnxmlutils && python setup.py install && cd ..
+  - pip install git+https://github.com/Connexions/rhaptos.cnxmlutils.git#egg=cnx-rhaptos.cnxmlutils
 
   # Installation for cnx-publishing
   # Install cssselect2 (unreleased), required by cnx-easybake
@@ -38,33 +35,25 @@ before_install:
   # Install cnx-easybake
   - pip install git+https://github.com/Connexions/cnx-easybake.git#egg=cnx-easybake
   # * Install cnx-epub
-  - git clone https://github.com/Connexions/cnx-epub.git
-  - cd cnx-epub && python setup.py install && cd ..
-
-  # * Install cnx-archive
-  - git clone https://github.com/Connexions/cnx-archive.git
-  - cd cnx-archive && python setup.py install && cd ..
+  - pip install git+https://github.com/Connexions/cnx-epub.git#egg=cnx-epub
   # * Install cnx-db
-  - git clone https://github.com/Connexions/cnx-db.git
-  - cd cnx-db && python setup.py install && cd ..
+  - pip install git+https://github.com/Connexions/cnx-db.git#egg=cnx-db
+  # * Install cnx-archive
+  - pip install git+https://github.com/Connexions/cnx-archive.git#egg=cnx-archive
   # Install the coverage utility and codecov reporting utility
   - pip install coverage
   - pip install codecov
 install:
   - pip install ".[test]"
 before_script:
-  # Set up postgres roles
-  - sudo -u postgres psql -d postgres -c "CREATE USER cnxarchive WITH SUPERUSER PASSWORD 'cnxarchive';"
-  # Set up the database
-  - sudo -u postgres createdb -O cnxarchive cnxarchive-testing
-  - git clone https://github.com/okbob/session_exec
-  - cd session_exec
-  - make USE_PGXS=1 -e && sudo make USE_PGXS=1 -e install
-  - cd ..
+  # Give cnxarchive superuser privileges on postgres
+  - docker exec cnxpublishing_db_1 /bin/bash -c "echo 'ALTER USER cnxarchive WITH SUPERUSER' | psql -U postgres postgres"
+  # Stop init_venv from doing anything
+  - docker exec cnxpublishing_db_1 /bin/bash -c "echo 'CREATE SCHEMA venv' | psql -U cnxarchive cnxarchive-testing"
   - pip install -U pytest pytest-runner pytest-cov
 script:
   # This is the same as `coverage run setup.py test`.
-  - pytest cnxpublishing
+  - AS_VENV_IMPORTABLE=false pytest cnxpublishing
 after_success:
   # Report test coverage to codecov.io
   - codecov

--- a/cnxpublishing/publish.py
+++ b/cnxpublishing/publish.py
@@ -184,6 +184,15 @@ def _insert_metadata(cursor, model, publisher, message):
             moduleid = None
         params['_moduleid'] = moduleid
 
+        # Verify that uuid is reserved in document_contols. If not, add it.
+        cursor.execute("SELECT * from document_controls where uuid = %s",
+                       (uuid,))
+        try:
+            _ = cursor.fetchone()[0]
+        except TypeError as exc:  # NoneType
+            cursor.execute("INSERT INTO document_controls (uuid) VALUES (%s)",
+                           (uuid,))
+
         created = model.metadata.get('created', None)
         # Format the statement to accept the identifiers.
         stmt = MODULE_INSERTION_TEMPLATE.format(**{

--- a/cnxpublishing/tasks.py
+++ b/cnxpublishing/tasks.py
@@ -11,6 +11,7 @@ from __future__ import absolute_import
 
 import celery
 import venusian
+from kombu import Queue
 from pyramid.scripting import prepare
 
 
@@ -69,6 +70,11 @@ def includeme(config):
         broker_url=settings['celery.broker'],
         result_backend=settings['celery.backend'],
         result_persistent=True,
+        task_default_queue='default',
+        task_queues=(
+            Queue('default'),
+            Queue('deferred'),
+        ),
     )
     # Override the existing Task class.
     config.registry.celery_app.Task = PyramidAwareTask

--- a/cnxpublishing/tests/test_db.py
+++ b/cnxpublishing/tests/test_db.py
@@ -19,12 +19,11 @@ except ImportError:
 
 import psycopg2
 import cnxepub
-from cnxdb.init import init_db
 from pyramid import testing
 
 from ..utils import join_ident_hash, split_ident_hash
 from . import use_cases
-from .testing import db_connect, integration_test_settings
+from .testing import db_connect, integration_test_settings, init_db
 
 
 VALID_LICENSE_URL = "http://creativecommons.org/licenses/by/4.0/"
@@ -71,7 +70,7 @@ class BaseDatabaseIntegrationTestCase(unittest.TestCase):
             cls._tear_down_database()
 
     def setUp(self):
-        init_db(self.db_conn_str, True)
+        init_db(self.db_conn_str)
 
         # Declare a request, so that we can use the route generator methods.
         request = testing.DummyRequest()

--- a/cnxpublishing/tests/test_publish.py
+++ b/cnxpublishing/tests/test_publish.py
@@ -18,7 +18,6 @@ except ImportError:
 import cnxepub
 import psycopg2
 from cnxarchive.utils import join_ident_hash
-from cnxdb.init import init_db
 from webob import Request
 from pyramid import testing
 
@@ -28,6 +27,7 @@ from .testing import (
     integration_test_settings,
     db_connection_factory,
     db_connect,
+    init_db,
     )
 from .test_db import BaseDatabaseIntegrationTestCase
 
@@ -62,7 +62,7 @@ class PublishIntegrationTestCase(unittest.TestCase):
         cls.db_connect = staticmethod(db_connection_factory())
 
     def setUp(self):
-        init_db(self.db_conn_str, True)
+        init_db(self.db_conn_str)
         self.config = testing.setUp(settings=self.settings)
 
     def tearDown(self):
@@ -471,7 +471,7 @@ class RepublishTestCase(unittest.TestCase):
         cls.db_conn_str = cls.settings[CONNECTION_STRING]
 
     def setUp(self):
-        init_db(self.db_conn_str, True)
+        init_db(self.db_conn_str)
         self.config = testing.setUp(settings=self.settings)
 
     def tearDown(self):

--- a/cnxpublishing/tests/test_subscribers.py
+++ b/cnxpublishing/tests/test_subscribers.py
@@ -43,7 +43,6 @@ def test_startup_event(db_cursor, complex_book_one,
 
 
 class TestPostPublicationProcessing(object):
-
     @pytest.fixture(autouse=True)
     def suite_fixture(self, scoped_pyramid_app, complex_book_one,
                       celery_worker):
@@ -194,3 +193,140 @@ class TestPostPublicationProcessing(object):
                           "WHERE module_ident = %s",
                           (self.module_ident,))
         db_cursor.fetchone()[0] == 'errored'
+
+    def test_duplicate_baking(self, db_cursor):
+        # Set up (setUp) creates the content, thus putting it in the
+        # post-publication state. We simply create the event associated
+        # with that state change.
+        event1 = self.make_event()
+
+        self.target(event1)
+
+        # While the baking is happening, if the module state is set to
+        # "post-publication" again, another event is created
+        event2 = self.make_event()
+
+        self.target(event2)
+
+        # Check there is only one request being queued
+        db_cursor.execute("SELECT count(*) "
+                          "FROM document_baking_result_associations "
+                          "WHERE module_ident = %s", (self.module_ident,))
+        assert db_cursor.fetchone()[0] == 1
+
+    def test_rebaking(self, db_cursor, mocker):
+        mock_bake = mocker.patch('cnxpublishing.subscribers.bake')
+
+        # Set up (setUp) creates the content, thus putting it in the
+        # post-publication state. We simply create the event associated
+        # with that state change.
+        event = self.make_event()
+
+        self.target(event)
+
+        db_cursor.execute("SELECT result_id::text "
+                          "FROM document_baking_result_associations "
+                          "WHERE module_ident = %s ", (self.module_ident,))
+        result_id = db_cursor.fetchone()[0]
+
+        from celery.result import AsyncResult
+        result = AsyncResult(id=result_id)
+        result.get()  # blocking operation
+        assert result.state == 'SUCCESS'
+        assert mock_bake.call_count == 1
+
+        # After baking is finished, if the module state is set to
+        # "post-publication" again, another event is created
+        event = self.make_event()
+
+        self.target(event)
+
+        db_cursor.execute("SELECT result_id::text "
+                          "FROM document_baking_result_associations "
+                          "WHERE module_ident = %s "
+                          "ORDER BY created DESC", (self.module_ident,))
+        result_id2 = db_cursor.fetchone()
+
+        assert result_id2 != result_id
+        result2 = AsyncResult(id=result_id2)
+        result2.get()  # blocking operation
+        assert result2.state == 'SUCCESS'
+        assert mock_bake.call_count == 2
+
+    def test_no_recipe(self, db_cursor, mocker):
+        mock_bake = mocker.patch('cnxpublishing.subscribers.bake')
+
+        # Set up (setUp) creates the content, thus putting it in the
+        # post-publication state. We simply create the event associated
+        # with that state change.
+
+        event = self.make_event()
+
+        # Delete the ruleset, to follow the no-recipe path
+
+        db_cursor.execute("DELETE FROM module_files "
+                          "WHERE filename = 'ruleset.css' "
+                          "AND  module_ident = %s ", (self.module_ident,))
+
+        db_cursor.connection.commit()
+
+        self.target(event)
+
+        db_cursor.execute("SELECT result_id::text "
+                          "FROM document_baking_result_associations "
+                          "WHERE module_ident = %s ", (self.module_ident,))
+        result_id = db_cursor.fetchone()[0]
+
+        from celery.result import AsyncResult
+        result = AsyncResult(id=result_id)
+        result.get()  # blocking operation
+        assert result.state == 'SUCCESS'
+        assert mock_bake.call_count == 0
+
+        db_cursor.execute("SELECT recipe, stateid "
+                          "FROM modules "
+                          "WHERE module_ident = %s ", (self.module_ident,))
+        result_recipe, result_stateid = db_cursor.fetchone()
+
+        assert result_recipe is None
+        assert result_stateid == 1
+
+    def test_priority(self, db_cursor, mocker, complex_book_one_v2):
+        from celery.exceptions import Retry
+
+        mock_retry = mocker.patch('celery.app.task.Task.retry')
+        mock_retry.return_value = Exception('Task can be retried')
+
+        binder_v2, ident_mapping = complex_book_one_v2
+        mock_bake = mocker.patch('cnxpublishing.subscribers.bake')
+        binder_v2_module_ident = ident_mapping[binder_v2.ident_hash]
+
+        # Create the post publication event for complex book one
+        event1 = self.make_event()
+
+        # Create the post publication event for complex book one v2
+        event2 = self.make_event(payload=self.make_payload(
+            module_ident=binder_v2_module_ident,
+            ident_hash=binder_v2.ident_hash))
+
+        self.target(event1)
+        self.target(event2)
+
+        db_cursor.execute("SELECT module_ident, result_id::text "
+                          "FROM document_baking_result_associations "
+                          "WHERE module_ident IN %s",
+                          ((self.module_ident, binder_v2_module_ident),))
+        result_ids = dict(db_cursor.fetchall())
+
+        from celery.result import AsyncResult
+        result1 = AsyncResult(id=result_ids[self.module_ident])
+        with pytest.raises(Exception) as exc_info:
+            result1.get()  # blocking operation
+            assert str(exc_info.exception) == 'Task can be retried'
+            assert mock_retry.call_args_list == [((), {'queue': 'deferred'})]
+
+        result2 = AsyncResult(id=result_ids[binder_v2_module_ident])
+        result2.get()  # blocking operation
+
+        assert mock_bake.call_count == 1
+        assert mock_bake.call_args[0][0].ident_hash == binder_v2.ident_hash

--- a/cnxpublishing/tests/testing.py
+++ b/cnxpublishing/tests/testing.py
@@ -9,6 +9,7 @@ import os
 import functools
 
 import psycopg2
+from cnxdb.init import init_db as _init_db
 from pyramid.paster import get_appsettings
 
 
@@ -65,3 +66,8 @@ def db_connect(method):
             with db_connection.cursor() as cursor:
                 return method(self, cursor, *args, **kwargs)
     return wrapped
+
+
+def init_db(db_conn_str):
+    venv = os.getenv('AS_VENV_IMPORTABLE', 'true').lower() == 'true'
+    _init_db(db_conn_str, venv)

--- a/cnxpublishing/tests/use_cases.py
+++ b/cnxpublishing/tests/use_cases.py
@@ -927,6 +927,31 @@ def setup_COMPLEX_BOOK_ONE_in_archive(test_case, cursor):
     return model
 
 
+def setup_COMPLEX_BOOK_ONE_v2_in_archive(test_case, cursor):
+    """Set up COMPLEX_BOOK_ONE v2"""
+    model = deepcopy(COMPLEX_BOOK_ONE)
+
+    publisher = 'ream'
+    publication_message = 'published via test setup'
+    # FIXME Use the REVISED_* id when it exists.
+    model.id = 'c3bb4bfb-3b53-41a9-bb03-583cf9ce3408'
+    model.metadata['version'] = '2.1'
+
+    doc = setup_PAGE_ONE_in_archive(test_case, cursor)
+    model[0][0] = doc
+    doc = setup_PAGE_TWO_in_archive(test_case, cursor)
+    model[0][1] = doc
+    doc = setup_PAGE_THREE_in_archive(test_case, cursor)
+    model[1][0] = doc
+    del model[1][1]
+
+    from ..publish import publish_model
+    if not _is_published(model.ident_hash, cursor):
+        publish_model(cursor, model, publisher, publication_message)
+    _set_uri(model)
+    return model
+
+
 def setup_COMPLEX_BOOK_TWO_in_archive(test_case, cursor):
     """Set up COMPLEX_BOOK_ONE"""
     model = deepcopy(COMPLEX_BOOK_TWO)

--- a/cnxpublishing/tests/views/base.py
+++ b/cnxpublishing/tests/views/base.py
@@ -12,13 +12,13 @@ import unittest
 import zipfile
 
 import cnxepub
-from cnxdb.init import init_db
 from webtest import TestApp
 from pyramid import testing
 
 from ..testing import (
     integration_test_settings,
     db_connection_factory,
+    init_db,
     )
 
 
@@ -135,7 +135,7 @@ class BaseFunctionalViewTestCase(unittest.TestCase, EPUBMixInTestCase):
     def setUp(self):
         EPUBMixInTestCase.setUp(self)
         config = testing.setUp(settings=self.settings)
-        init_db(self.db_conn_str, True)
+        init_db(self.db_conn_str)
 
         # Assign API keys for testing
         self.set_up_api_keys()

--- a/cnxpublishing/tests/views/test_admin.py
+++ b/cnxpublishing/tests/views/test_admin.py
@@ -5,11 +5,17 @@
 # Public License version 3 (AGPLv3).
 # See LICENCE.txt for details.
 # ###
+import pytest
 import unittest
+
 from datetime import datetime
 
 from cnxdb.init import init_db
 from pyramid import testing
+from pyramid import httpexceptions
+import pytest
+import psycopg2
+from pyramid.httpexceptions import HTTPBadRequest
 
 from .. import use_cases
 from ..testing import (
@@ -18,13 +24,32 @@ from ..testing import (
     )
 
 
-# FIXME There is an issue with setting up the celery app more than once.
-#       Apparently, creating the app a second time doesn't really create
-#       it again. There is some global state hanging around that we can't
-#       easily get at. This causes the task results tables used in these
-#       views to not exist, because the code believes it's already been
-#       initialized.
-@unittest.skip("celery is too global")
+def add_data(self):
+    with self.db_connect() as db_conn:
+        with db_conn.cursor() as cursor:
+            # Insert one book into archive.
+            book = use_cases.setup_BOOK_in_archive(self, cursor)
+            db_conn.commit()
+
+            # Insert some data into the association table.
+            cursor.execute("""
+            INSERT INTO document_baking_result_associations
+            (result_id, module_ident)
+            SELECT
+            uuid_generate_v4(),
+            (SELECT module_ident FROM modules ORDER BY module_ident DESC LIMIT 1);""")
+            db_conn.commit()
+
+            cursor.execute("""\
+            INSERT INTO document_baking_result_associations
+            (result_id, module_ident)
+            SELECT
+            uuid_generate_v4(),
+            (SELECT module_ident FROM modules ORDER BY module_ident DESC LIMIT 1);""")
+    return book
+
+
+@pytest.mark.usefixtures('scoped_pyramid_app')
 class PostPublicationsViewsTestCase(unittest.TestCase):
     maxDiff = None
 
@@ -34,18 +59,6 @@ class PostPublicationsViewsTestCase(unittest.TestCase):
         from cnxpublishing.config import CONNECTION_STRING
         cls.db_conn_str = cls.settings[CONNECTION_STRING]
         cls.db_connect = staticmethod(db_connection_factory())
-
-    def setUp(self):
-        self.config = testing.setUp(settings=self.settings)
-        self.config.include('cnxpublishing.tasks')
-        init_db(self.db_conn_str, True)
-
-    def tearDown(self):
-        with self.db_connect() as db_conn:
-            with db_conn.cursor() as cursor:
-                cursor.execute("DROP SCHEMA public CASCADE")
-                cursor.execute("CREATE SCHEMA public")
-        testing.tearDown()
 
     @property
     def target(self):
@@ -62,27 +75,7 @@ class PostPublicationsViewsTestCase(unittest.TestCase):
     def test(self):
         request = testing.DummyRequest()
 
-        with self.db_connect() as db_conn:
-            with db_conn.cursor() as cursor:
-                # Insert one book into archive.
-                book = use_cases.setup_BOOK_in_archive(self, cursor)
-                db_conn.commit()
-
-                # Insert some data into the association table.
-                cursor.execute("""
-INSERT INTO document_baking_result_associations
-  (result_id, module_ident)
-SELECT
-  uuid_generate_v4(),
-  (SELECT module_ident FROM modules ORDER BY module_ident DESC LIMIT 1);""")
-                db_conn.commit()
-
-                cursor.execute("""\
-INSERT INTO document_baking_result_associations
-  (result_id, module_ident)
-SELECT
-  uuid_generate_v4(),
-  (SELECT module_ident FROM modules ORDER BY module_ident DESC LIMIT 1);""")
+        book = add_data(self)
 
         resp_data = self.target(request)
         self.assertEqual({
@@ -98,6 +91,92 @@ SELECT
                  'state_message': '',
                  'title': 'Book of Infinity'},
                 ]}, resp_data)
+
+
+class PrintStyleViewsTestCase(unittest.TestCase):
+    maxDiff = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.settings = integration_test_settings()
+        from cnxpublishing.config import CONNECTION_STRING
+        cls.db_conn_str = cls.settings[CONNECTION_STRING]
+        cls.db_connect = staticmethod(db_connection_factory())
+
+    def setUp(self):
+        self.config = testing.setUp(settings=self.settings)
+        self.config.include('cnxpublishing.tasks')
+        self.config.add_route('get-content', '/contents/{ident_hash}')
+        self.config.add_route('admin-print-style-single',
+                              '/a/print-style/{style}')
+        init_db(self.db_conn_str, True)
+        with self.db_connect() as db_conn:
+            with db_conn.cursor() as cursor:
+                cursor.execute("""INSERT INTO files
+                                  (file, media_type) VALUES ('file', 'css');""")
+                cursor.execute("""INSERT INTO print_style_recipes
+                                  (print_style, fileid, tag)
+                                  VALUES ('ccap-physics', 1, '1.0');""")
+
+    def tearDown(self):
+        with self.db_connect() as db_conn:
+            with db_conn.cursor() as cursor:
+                cursor.execute("DROP SCHEMA public CASCADE")
+                cursor.execute("CREATE SCHEMA public")
+        testing.tearDown()
+
+    def test_print_styles(self):
+        request = testing.DummyRequest()
+
+        from ...views.admin import admin_print_styles
+        content = admin_print_styles(request)
+        self.assertEqual(1, len(content['styles']))
+        self.assertEqual(content['styles'][0],
+                         {'print_style': 'ccap-physics',
+                          'type': 'web',
+                          'revised': content['styles'][0]['revised'],
+                          'number': 0,
+                          'tag': '1.0',
+                          'link': '/a/print-style/ccap-physics'})
+
+    def test_print_style_single(self):
+        request = testing.DummyRequest()
+        with self.db_connect() as db_conn:
+            with db_conn.cursor() as cursor:
+                cursor.execute("""INSERT INTO latest_modules
+                                  (print_style, portal_type, name, licenseid,
+                                        doctype, uuid, created, revised, recipe)
+                                  VALUES ('ccap-physics', 'Collection', 'test', 1,
+                                        'doc', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', now(), now(), 1);""")
+
+        print_style = 'ccap-physics'
+        request.matchdict['style'] = print_style
+
+        from ...views.admin import admin_print_styles_single
+        content = admin_print_styles_single(request)
+        self.assertEqual(content['print_style'], 'ccap-physics')
+        self.assertEqual(content['recipe_type'], 'web')
+        self.assertEqual(len(content['collections']), 1)
+        self.assertEqual(content['collections'][0],
+                         {'title': 'test',
+                          'authors': None,
+                          'revised': content['collections'][0]['revised'],
+                          'link': '/contents/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa@',
+                          'tag': '1.0',
+                          'recipe': 1,
+                          'ident_hash': 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa@',
+                          'status': 'current'})
+
+    def test_print_style_single_no_style(self):
+        request = testing.DummyRequest()
+        print_style = 'fake-print-style'
+        request.matchdict['style'] = print_style
+
+        from ...views.admin import admin_print_styles_single
+        with self.assertRaises(httpexceptions.HTTPNotFound) as cm:
+            admin_print_styles_single(request)
+
+        self.assertEqual(cm.exception.message, "Invalid Print Style: fake-print-style")
 
 
 class SiteMessageViewsTestCase(unittest.TestCase):
@@ -232,3 +311,240 @@ class SiteMessageViewsTestCase(unittest.TestCase):
                           'end_date': '2017-01-03',
                           'end_time': '00:03',
                           'id': '1'}, results)
+
+
+@pytest.mark.usefixtures('scoped_pyramid_app')
+class ContentStatusViewsTestCase(unittest.TestCase):
+    maxDiff = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.settings = integration_test_settings()
+        from cnxpublishing.config import CONNECTION_STRING
+        cls.db_conn_str = cls.settings[CONNECTION_STRING]
+        cls.db_connect = staticmethod(db_connection_factory())
+
+    def setUp(self):
+        self.config = testing.setUp(settings=self.settings)
+        self.config.include('cnxpublishing.tasks')
+        self.config.add_route('admin-content-status-single',
+                              '/a/content-status/{uuid}')
+        self.config.add_route('get-content', '/contents/{ident_hash}')
+
+        add_data(self)
+
+    def test_admin_content_status_no_filters(self):
+        request = testing.DummyRequest()
+
+        from ...views.admin import admin_content_status
+        content = admin_content_status(request)
+        self.assertEqual({
+            'SUCCESS': 'checked',
+            'PENDING': 'checked',
+            'STARTED': 'checked',
+            'RETRY': 'checked',
+            'FAILURE': 'checked',
+            'start_entry': 0,
+            'page': 1,
+            'num_entries': 100,
+            'sort': 'bpsa.created DESC',
+            'sort_created': 'fa fa-angle-down',
+            'total_entries': 2,
+            'states': content['states']
+        }, content)
+        self.assertEqual(
+            content['states'],
+            sorted(content['states'], key=lambda x: x['created'], reverse=True))
+
+    def test_admin_content_status_w_filters(self):
+        request = testing.DummyRequest()
+
+        request.GET = {'page': 1,
+                       'number': 2,
+                       'sort': 'STATE ASC',
+                       'author': 'charrose',
+                       'pending_filter': 'PENDING'}
+        from ...views.admin import admin_content_status
+        content = admin_content_status(request)
+        self.assertEqual({
+            'PENDING': 'checked',
+            'start_entry': 0,
+            'page': 1,
+            'num_entries': 2,
+            'author': 'charrose',
+            'sort': 'STATE ASC',
+            'sort_state': 'fa fa-angle-up',
+            'total_entries': 2,
+            'states': content['states']
+        }, content)
+        self.assertEqual(len(content['states']), 2)
+        for state in content['states']:
+            self.assertTrue('charrose' in state['authors'])
+            self.assertTrue('PENDING' in state['state'])
+        self.assertEqual(
+            content['states'],
+            sorted(content['states'], key=lambda x: x['state']))
+
+    def test_admin_content_status_stale_recipe(self):
+        uuid = 'd5dbbd8e-d137-4f89-9d0a-3ac8db53d8ee'
+        with psycopg2.connect(self.db_conn_str) as db_conn:
+            with db_conn.cursor() as cursor:
+                cursor.execute("""\
+                    UPDATE modules SET recipe=1
+                    WHERE uuid=%s;
+                    """, (uuid, ))
+
+        request = testing.DummyRequest()
+        request.GET = {'page': 1,
+                       'number': 1}
+        from ...views.admin import admin_content_status
+        content = admin_content_status(request)
+        print [x['state'] for x in content['states']]
+        self.assertEqual('PENDING stale_content stale_recipe',
+                         content['states'][0]['state'])
+
+    def test_admin_content_status_bad_sort(self):
+        request = testing.DummyRequest()
+
+        request.GET = {'sort': 'bad sort'}
+        from ...views.admin import admin_content_status
+        with self.assertRaises(HTTPBadRequest) as caught_exc:
+            admin_content_status(request)
+        self.assertIn('invalid sort', caught_exc.exception.message)
+
+    def test_admin_content_status_bad_page_number(self):
+        request = testing.DummyRequest()
+
+        request.GET = {'page': 'abc'}
+        from ...views.admin import admin_content_status
+        with self.assertRaises(HTTPBadRequest) as caught_exc:
+            admin_content_status(request)
+        self.assertIn('invalid page', caught_exc.exception.message)
+
+    def test_admin_content_status_single_page(self):
+        request = testing.DummyRequest()
+
+        uuid = 'd5dbbd8e-d137-4f89-9d0a-3ac8db53d8ee'
+        request.matchdict['uuid'] = uuid
+
+        from ...views.admin import admin_content_status_single
+        content = admin_content_status_single(request)
+        self.assertEqual({
+            'uuid': uuid,
+            'title': 'Book of Infinity',
+            'authors': 'marknewlyn, charrose',
+            'print_style': None,
+            'current_recipe': None,
+            'current_ident': 2,
+            'current_state': u'PENDING stale_content',
+            'states': [
+                {'version': '1.1',
+                 'recipe': None,
+                 'created': content['states'][0]['created'],
+                 'state': 'PENDING stale_content',
+                 'state_message': ''},
+                {'version': '1.1',
+                 'recipe': None,
+                 'created': content['states'][1]['created'],
+                 'state': 'PENDING stale_content',
+                 'state_message': ''}
+            ]
+        }, content)
+
+    def test_admin_content_status_single_bad_uuid(self):
+        request = testing.DummyRequest()
+
+        uuid = 'bad-uuid'
+        request.matchdict['uuid'] = uuid
+
+        from ...views.admin import admin_content_status_single
+        with self.assertRaises(HTTPBadRequest) as caught_exc:
+            admin_content_status_single(request)
+        self.assertIn('is not a valid uuid', caught_exc.exception.message)
+
+    def test_admin_content_status_single_uuid_no_book(self):
+        request = testing.DummyRequest()
+
+        uuid = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+        request.matchdict['uuid'] = uuid
+
+        from ...views.admin import admin_content_status_single
+        with self.assertRaises(HTTPBadRequest) as caught_exc:
+            admin_content_status_single(request)
+        self.assertIn('not a book', caught_exc.exception.message)
+
+    def test_admin_content_status_single_stale_recipe(self):
+        uuid = 'd5dbbd8e-d137-4f89-9d0a-3ac8db53d8ee'
+        with psycopg2.connect(self.db_conn_str) as db_conn:
+            with db_conn.cursor() as cursor:
+                cursor.execute("""\
+                    UPDATE modules SET recipe=1
+                    WHERE uuid=%s;
+                    """, (uuid, ))
+
+        request = testing.DummyRequest()
+
+        uuid = 'd5dbbd8e-d137-4f89-9d0a-3ac8db53d8ee'
+        request.matchdict['uuid'] = uuid
+
+        from ...views.admin import admin_content_status_single
+
+        request.GET = {'page': 1,
+                       'number': 1}
+        from ...views.admin import admin_content_status
+        content = admin_content_status_single(request)
+        print [x['state'] for x in content['states']]
+        self.assertEqual('PENDING stale_recipe stale_content',
+                         content['states'][0]['state'])
+
+    def test_admin_content_status_single_page_POST_already_baking(self):
+        uuid = 'd5dbbd8e-d137-4f89-9d0a-3ac8db53d8ee'
+        with psycopg2.connect(self.db_conn_str) as db_conn:
+            with db_conn.cursor() as cursor:
+                cursor.execute("""\
+                    UPDATE modules SET stateid=5
+                    WHERE uuid=%s;
+                    """, (uuid, ))
+
+        request = testing.DummyRequest()
+        from ...views.admin import admin_content_status_single_POST
+
+        request.matchdict['uuid'] = uuid
+        content = admin_content_status_single_POST(request)
+        self.assertEqual(content['response'],
+                         'Book of Infinity is already baking/set to bake')
+
+    def test_admin_content_status_single_page_POST_bake(self):
+        uuid = 'd5dbbd8e-d137-4f89-9d0a-3ac8db53d8ee'
+        with psycopg2.connect(self.db_conn_str) as db_conn:
+            with db_conn.cursor() as cursor:
+                cursor.execute("""\
+                    UPDATE modules SET stateid=1
+                    WHERE uuid=%s;
+                    """, (uuid, ))
+
+        request = testing.DummyRequest()
+        from ...views.admin import admin_content_status_single_POST
+
+        request.matchdict['uuid'] = uuid
+        content = admin_content_status_single_POST(request)
+        self.assertEqual(content['response'],
+                         'Book of Infinity set to bake!')
+
+        with psycopg2.connect(self.db_conn_str) as db_conn:
+            with db_conn.cursor() as cursor:
+                cursor.execute("""\
+                    SELECT stateid FROM modules WHERE uuid=%s;
+                    """, (uuid, ))
+                state = cursor.fetchone()
+                self.assertEqual(state[0], 5)
+
+    def test_admin_content_status_single_page_POST_bad_uuid(self):
+        request = testing.DummyRequest()
+        from ...views.admin import admin_content_status_single_POST
+
+        uuid = 'd5dbbd8e-d137-4f89-9d0a-eeeeeeeeeeee'
+        request.matchdict['uuid'] = uuid
+        with self.assertRaises(HTTPBadRequest) as caught_exc:
+            content = admin_content_status_single_POST(request)
+        self.assertIn('not a book', caught_exc.exception.message)

--- a/cnxpublishing/tests/views/test_api_keys.py
+++ b/cnxpublishing/tests/views/test_api_keys.py
@@ -7,12 +7,12 @@
 # ###
 import unittest
 
-from cnxdb.init import init_db
 from pyramid import testing
 
 from ..testing import (
     integration_test_settings,
     db_connection_factory,
+    init_db,
     )
 
 
@@ -31,7 +31,7 @@ class ApiKeyViewsTestCase(unittest.TestCase):
 
     def setUp(self):
         self.config = testing.setUp(settings=self.settings)
-        init_db(self.db_conn_str, True)
+        init_db(self.db_conn_str)
 
     def tearDown(self):
         with self.db_connect() as db_conn:

--- a/cnxpublishing/views/__init__.py
+++ b/cnxpublishing/views/__init__.py
@@ -56,11 +56,11 @@ def declare_browsable_routes(config):
     add_route('admin-edit-site-message-POST', '/a/site-messages/{id}/',
               request_method='POST')
 
-    add_route('admin-print-style', '/a/print-style/')
-    add_route('admin-print-style-single', '/a/print-style/{style}')
-
     add_route('admin-content-status', '/a/content-status/')
     add_route('admin-content-status-single', '/a/content-status/{uuid}')
+
+    add_route('admin-print-style', '/a/print-style/')
+    add_route('admin-print-style-single', '/a/print-style/{style}')
 
 
 def includeme(config):

--- a/cnxpublishing/views/__init__.py
+++ b/cnxpublishing/views/__init__.py
@@ -56,6 +56,12 @@ def declare_browsable_routes(config):
     add_route('admin-edit-site-message-POST', '/a/site-messages/{id}/',
               request_method='POST')
 
+    add_route('admin-print-style', '/a/print-style/')
+    add_route('admin-print-style-single', '/a/print-style/{style}')
+
+    add_route('admin-content-status', '/a/content-status/')
+    add_route('admin-content-status-single', '/a/content-status/{uuid}')
+
 
 def includeme(config):
     """Declare all routes."""

--- a/cnxpublishing/views/admin.py
+++ b/cnxpublishing/views/admin.py
@@ -6,17 +6,38 @@
 # See LICENCE.txt for details.
 # ###
 from __future__ import absolute_import
-
 from datetime import datetime, timedelta
+from uuid import UUID
 
 import psycopg2
 from celery.result import AsyncResult
 from pyramid import httpexceptions
 from pyramid.view import view_config
 
+from cnxarchive.utils.ident_hash import IdentHashError
+
 from .. import config
 from .moderation import get_moderation
 from .api_keys import get_api_keys
+
+STATE_ICONS = {
+    "SUCCESS": {'class': 'fa fa-check-square',
+                'style': 'font-size:20px;color:limeGreen'},
+    "STARTED": {'class': 'fa fa-exclamation-triangle',
+                'style': 'font-size:20px;color:gold'},
+    "PENDING": {'class': 'fa fa-exclamation-triangle',
+                'style': 'font-size:20px;color:gold'},
+    "RETRY": {'class': 'a fa-close',
+              'style': 'font-size:20px;color:red'},
+    "FAILURE": {'class': 'fa fa-close',
+                'style': 'font-size:20px;color:red'}}
+SORTS_DICT = {
+    "bpsa.created": 'created',
+    "m.name": 'name',
+    "STATE": 'state'}
+ARROW_MATCH = {
+    "ASC": 'fa fa-angle-up',
+    "DESC": 'fa fa-angle-down'}
 
 
 @view_config(route_name='admin-index', request_method='GET',
@@ -36,6 +57,12 @@ def admin_index(request):  # pragma: no cover
              },
             {'name': 'Message Banners',
              'uri': request.route_url('admin-add-site-messages'),
+             },
+            {'name': 'Print Styles',
+             'uri': request.route_url('admin-print-style'),
+             },
+            {'name': 'Content Status',
+             'uri': request.route_url('admin-content-status'),
              },
             ],
         }
@@ -270,4 +297,364 @@ def admin_edit_site_message_POST(request):
 
     args = admin_edit_site_message(request)
     args['response'] = "Message successfully Updated"
+    return args
+
+
+@view_config(route_name='admin-print-style', request_method='GET',
+             renderer='cnxpublishing.views:templates/print-style.html',
+             permission='administer')
+def admin_print_styles(request):
+    """
+    Returns a dictionary of all unique print_styles, and their latest tag,
+    revision, and recipe_type.
+    """
+    settings = request.registry.settings
+    db_conn_str = settings[config.CONNECTION_STRING]
+    styles = []
+    with psycopg2.connect(db_conn_str) as db_conn:
+        with db_conn.cursor() as cursor:
+            cursor.execute("""\
+                WITH latest AS (
+                    SELECT print_style, max(revised) AS revised
+                        FROM print_style_recipes
+                        GROUP BY print_style
+                ) SELECT ps.print_style, ps.recipe_type, ps.revised, tag,
+                    (SELECT count(*)
+                        FROM latest_modules AS lm
+                        WHERE lm.print_style = ps.print_style AND
+                              lm.portal_type = 'Collection')
+                    FROM latest
+                    JOIN print_style_recipes AS ps
+                    ON ps.print_style = latest.print_style AND
+                       ps.revised = latest.revised;
+                """)
+            for row in cursor.fetchall():
+                styles.append({
+                    'print_style': row[0],
+                    'type': row[1],
+                    'revised': row[2],
+                    'tag': row[3],
+                    'number': row[4],
+                    'link': request.route_path('admin-print-style-single',
+                                               style=row[0])
+                })
+    return {'styles': styles}
+
+
+@view_config(route_name='admin-print-style-single', request_method='GET',
+             renderer='cnxpublishing.views:templates/print-style-single.html',
+             permission='administer')
+def admin_print_styles_single(request):
+    """ Returns all books with any version of the given print style.
+
+    Returns the print_style, recipe type, num books using the print_style,
+    along with a dictionary of the book, author, revision date, recipie,
+    tag of the print_style, and a link to the content.
+    """
+    settings = request.registry.settings
+    db_conn_str = settings[config.CONNECTION_STRING]
+    style = request.matchdict['style']
+    # do db search to get file id and other info on the print_style
+    with psycopg2.connect(db_conn_str) as db_conn:
+        with db_conn.cursor() as cursor:
+            cursor.execute("""
+                SELECT fileid, recipe_type
+                FROM print_style_recipes
+                WHERE print_style=%s
+                ORDER BY revised DESC;
+                """, vars=(style,))
+            info = cursor.fetchall()
+            if len(info) < 1:
+                raise httpexceptions.HTTPNotFound(
+                    'Invalid Print Style: {}'.format(style))
+            current_recipe = info[0][0]
+            recipe_type = info[0][1]
+
+            collections = []
+            cursor.execute("""\
+                SELECT name, authors, lm.revised, lm.recipe, psr.tag,
+                    ident_hash(uuid, major_version, minor_version)
+                FROM latest_modules as lm
+                JOIN print_style_recipes as psr
+                ON (psr.print_style = lm.print_style and
+                    psr.fileid = lm.recipe)
+                WHERE lm.print_style=%s
+                AND portal_type='Collection'
+                ORDER BY psr.tag DESC;
+                """, vars=(style,))
+            for row in cursor.fetchall():
+                recipe = row[3]
+                status = 'current'
+                if recipe != current_recipe:
+                    status = 'stale'
+                collections.append({
+                    'title': row[0].decode('utf-8'),
+                    'authors': row[1],
+                    'revised': row[2],
+                    'recipe': row[3],
+                    'tag': row[4],
+                    'ident_hash': row[-1],
+                    'link': request.route_path('get-content',
+                                               ident_hash=row[-1]),
+                    'status': status,
+
+                })
+    return {'number': len(collections),
+            'collections': collections,
+            'print_style': style,
+            'recipe_type': recipe_type}
+
+
+def get_baking_statuses_sql(get_request):
+    """ Creates SQL to get info on baking books filtered from GET request.
+
+    All books that have ever attmenpted to bake will be retured if they
+    pass the filters in the GET request.
+    If a single book has been requested to bake multiple times there will
+    be a row for each of the baking attempts.
+    By default the results are sorted in descending order of when they were
+    requested to bake.
+    """
+    args = {}
+    sort = get_request.get('sort', 'bpsa.created DESC')
+    if (len(sort.split(" ")) != 2 or
+            sort.split(" ")[0] not in SORTS_DICT.keys() or
+            sort.split(" ")[1] not in ARROW_MATCH.keys()):
+        raise httpexceptions.HTTPBadRequest(
+            'invalid sort: {}'.format(sort))
+    if sort == "STATE ASC" or sort == "STATE DESC":
+        sort = 'bpsa.created DESC'
+    uuid_filter = get_request.get('uuid', '')
+    author_filter = get_request.get('author', '')
+
+    sql_filters = "WHERE"
+    if uuid_filter != '':
+        args['uuid'] = uuid_filter
+        sql_filters += " m.uuid=%(uuid)s AND "
+    if author_filter != '':
+        author_filter = author_filter.decode('utf-8')
+        sql_filters += "%(author)s=ANY(m.authors) "
+        args["author"] = author_filter
+
+    if sql_filters.endswith("AND "):
+        sql_filters = sql_filters[:-4]
+    if sql_filters == "WHERE":
+        sql_filters = ""
+
+    statement = """
+                SELECT m.name, m.authors, m.uuid, m.print_style,
+                       ps.fileid as latest_recipe,  m.recipe,
+                       module_version(lm.major_version, lm.minor_version)
+                        as latest_version,
+                       module_version(m.major_version, m.minor_version)
+                        as cur_version,
+                       m.module_ident,
+                       ident_hash(m.uuid, m.major_version, m.minor_version),
+                       bpsa.created, bpsa.result_id::text
+                FROM document_baking_result_associations AS bpsa
+                INNER JOIN modules AS m USING (module_ident)
+                LEFT JOIN print_style_recipes as ps
+                    ON ps.print_style=m.print_style
+                LEFT JOIN latest_modules as lm
+                    ON lm.uuid=m.uuid
+                {}
+                ORDER BY {};
+                """.format(sql_filters, sort)
+    args.update({'sort': sort})
+    return statement, args
+
+
+def format_authors(authors):
+    if not authors:
+        return ""
+    return ', '.join([author.decode('utf-8') for author in authors])
+
+
+@view_config(route_name='admin-content-status', request_method='GET',
+             renderer='cnxpublishing.views:templates/content-status.html',
+             permission='administer')
+def admin_content_status(request):
+    """
+    Returns a dictionary with the states and info of baking books,
+    and the filters from the GET request to pre-populate the form.
+    """
+    settings = request.registry.settings
+    db_conn_str = settings[config.CONNECTION_STRING]
+    statement, sql_args = get_baking_statuses_sql(request.GET)
+    states = []
+    with psycopg2.connect(db_conn_str) as db_conn:
+        with db_conn.cursor() as cursor:
+            cursor.execute(statement, vars=sql_args)
+            for row in cursor.fetchall():
+                message = ''
+                result_id = row[-1]
+                result = AsyncResult(id=result_id)
+                if result.failed():  # pragma: no cover
+                    message = result.traceback.split("\n")[-2]
+                latest_recipe = row[4]
+                current_recipe = row[5]
+                latest_version = row[6]
+                current_version = row[7]
+                state = str(result.state)
+                if current_version != latest_version:
+                    state += ' stale_content'
+                if current_recipe != latest_recipe:
+                    state += ' stale_recipe'
+                state_icon = result.state
+                if state[:7] == "SUCCESS" and len(state) > 7:
+                    state_icon = 'PENDING'
+                states.append({
+                    'title': row[0].decode('utf-8'),
+                    'authors': format_authors(row[1]),
+                    'uuid': row[2],
+                    'print_style': row[3],
+                    'recipe': row[4],
+                    'created': row[-2],
+                    'state': state,
+                    'state_message': message,
+                    'state_icon': STATE_ICONS[state_icon]['class'],
+                    'state_icon_style': STATE_ICONS[state_icon]['style'],
+                    'status_link': request.route_path(
+                        'admin-content-status-single', uuid=row[2]),
+                    'content_link': request.route_path(
+                        'get-content', ident_hash=row[-3])
+                })
+    status_filters = [request.GET.get('pending_filter', ''),
+                      request.GET.get('started_filter', ''),
+                      request.GET.get('retry_filter', ''),
+                      request.GET.get('failure_filter', ''),
+                      request.GET.get('success_filter', '')]
+    status_filters = [x for x in status_filters if x != '']
+    if not status_filters:
+        status_filters = ["PENDING", "STARTED", "RETRY", "FAILURE", "SUCCESS"]
+        final_states = states
+    else:
+        final_states = []
+        for state in states:
+            if state['state'].split(' ')[0] in status_filters:
+                final_states.append(state)
+    sort = request.GET.get('sort', 'bpsa.created DESC')
+    sort_match = SORTS_DICT[sort.split(' ')[0]]
+    sort_arrow = ARROW_MATCH[sort.split(' ')[1]]
+    if sort == "STATE ASC":
+        final_states = sorted(final_states, key=lambda x: x['state'])
+    if sort == "STATE DESC":
+        final_states = sorted(final_states,
+                              key=lambda x: x['state'], reverse=True)
+
+    num_entries = request.GET.get('number', 100)
+    page = request.GET.get('page', 1)
+    try:
+        page = int(page)
+        num_entries = int(num_entries)
+        start_entry = (page - 1) * num_entries
+    except ValueError:
+        raise httpexceptions.HTTPBadRequest(
+            'invalid page({}) or entries per page({})'.
+            format(page, num_entries))
+    final_states = final_states[start_entry: start_entry + num_entries]
+
+    returns = sql_args
+    returns.update({'start_entry': start_entry,
+                    'num_entries': num_entries,
+                    'page': page,
+                    'total_entries': len(final_states),
+                    'states': final_states,
+                    'sort_' + sort_match: sort_arrow,
+                    'sort': sort})
+    for f in status_filters:
+        returns[f] = "checked"
+    return returns
+
+
+@view_config(route_name='admin-content-status-single', request_method='GET',
+             renderer='templates/content-status-single.html',
+             permission='administer')
+def admin_content_status_single(request):
+    """
+    Returns a dictionary with all the past baking statuses of a single book.
+    """
+    uuid = request.matchdict['uuid']
+    try:
+        UUID(uuid)
+    except ValueError:
+        raise httpexceptions.HTTPBadRequest(
+            '{} is not a valid uuid'.format(uuid))
+
+    settings = request.registry.settings
+    statement, sql_args = get_baking_statuses_sql({'uuid': uuid})
+    with psycopg2.connect(settings[config.CONNECTION_STRING]) as db_conn:
+        with db_conn.cursor() as cursor:
+            cursor.execute(statement, sql_args)
+            modules = cursor.fetchall()
+            if len(modules) == 0:
+                raise httpexceptions.HTTPBadRequest(
+                    '{} is not a book'.format(uuid))
+
+            states = []
+            collection_info = modules[0]
+
+            for row in modules:
+                message = ''
+                result_id = row[-1]
+                result = AsyncResult(id=result_id)
+                if result.failed():  # pragma: no cover
+                    message = result.traceback
+                latest_recipe = row[4]
+                current_recipe = row[5]
+                latest_version = row[6]
+                current_version = row[7]
+                state = result.state
+                if current_recipe != latest_recipe:
+                    state += ' stale_recipe'
+                if current_version != latest_version:
+                    state += ' stale_content'
+                states.append({
+                    'version': row[7],
+                    'recipe': row[5],
+                    'created': str(row[-2]),
+                    'state': state,
+                    'state_message': message,
+                })
+
+    return {'uuid': str(collection_info[2]),
+            'title': collection_info[0].decode('utf-8'),
+            'authors': format_authors(collection_info[1]),
+            'print_style': collection_info[3],
+            'current_recipe': collection_info[4],
+            'current_ident': collection_info[8],
+            'current_state': states[0]['state'],
+            'states': states}
+
+
+@view_config(route_name='admin-content-status-single', request_method='POST',
+             renderer='templates/content-status-single.html',
+             permission='administer')
+def admin_content_status_single_POST(request):
+    """ Retriggers baking for a given book. """
+    args = admin_content_status_single(request)
+    title = args['title']
+    if args['current_state'] == 'SUCCESS':
+        args['response'] = title + ' is not stale, no need to bake'
+        return args
+
+    settings = request.registry.settings
+    with psycopg2.connect(settings[config.CONNECTION_STRING]) as db_conn:
+        with db_conn.cursor() as cursor:
+            cursor.execute("SELECT stateid FROM modules WHERE module_ident=%s",
+                           vars=(args['current_ident'],))
+            data = cursor.fetchall()
+            if len(data) == 0:
+                raise httpexceptions.HTTPBadRequest(
+                    'invalid module_ident: {}'.format(args['current_ident']))
+            if data[0][0] == 5 or data[0][0] == 6:
+                args['response'] = title + ' is already baking/set to bake'
+                return args
+
+            cursor.execute("""UPDATE modules SET stateid=5
+                           WHERE module_ident=%s""",
+                           vars=(args['current_ident'],))
+
+            args['response'] = title + " set to bake!"
+
     return args

--- a/cnxpublishing/views/api_keys.py
+++ b/cnxpublishing/views/api_keys.py
@@ -5,10 +5,9 @@
 # Public License version 3 (AGPLv3).
 # See LICENCE.txt for details.
 # ###
-import psycopg2
 from pyramid.view import view_config
 
-from .. import config
+from ..db import db_connect
 
 
 @view_config(route_name='api-keys', request_method='GET',
@@ -16,9 +15,7 @@ from .. import config
              renderer='json', permission='administer')
 def get_api_keys(request):
     """Return the list of API keys."""
-    settings = request.registry.settings
-
-    with psycopg2.connect(settings[config.CONNECTION_STRING]) as db_conn:
+    with db_connect() as db_conn:
         with db_conn.cursor() as cursor:
             cursor.execute("""\
 SELECT row_to_json(combined_rows) FROM (

--- a/cnxpublishing/views/templates/base.html
+++ b/cnxpublishing/views/templates/base.html
@@ -9,7 +9,7 @@
 
     <link rel="stylesheet" href="/static/css/normalize.min.css">
     <link rel="stylesheet" href="/static/css/main.css">
-
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
     <script src="/static/js/vendor/modernizr-2.8.3.min.js"></script>
     {% block head %}
     {% endblock %}

--- a/cnxpublishing/views/templates/content-status-single.html
+++ b/cnxpublishing/views/templates/content-status-single.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+{% block content %}
+  <h1>Content Status History for single book</h1>
+
+  <p><b>uuid:</b> {{uuid}}</p>
+  <p><b>Title:</b> {{title}}</p>
+  <p><b>Authors:</b> {{authors}}</p>
+  <p><b>Print Style:</b> {{print_style}}</p>
+  <p><b>CURRENT STATE:</b> {{current_state}}
+  <form method="post" id="bake_button">
+    <input hidden type="text" value="current_state">
+    <input type="submit" value="BAKE">
+  </form>
+  <br>
+  <div><b>{{response}}</b></div>
+  <br><br><br>
+
+  {% for state in states%}
+    <b>Version:</b> {{state.version}} &emsp;&emsp;&emsp;
+    <b>Created:</b> {{state.created}} &emsp;&emsp;&emsp;
+    <b>Recipie:</b> {{state.recipe}} &emsp;&emsp;&emsp;
+    <b>State:</b> {{state.state}}<br>
+    <b>Message:</b><pre>{{state.state_message}}</pre>
+    <br><br>
+  {% endfor %}
+
+{% endblock %}

--- a/cnxpublishing/views/templates/content-status-single.html
+++ b/cnxpublishing/views/templates/content-status-single.html
@@ -18,7 +18,7 @@
   {% for state in states%}
     <b>Version:</b> {{state.version}} &emsp;&emsp;&emsp;
     <b>Created:</b> {{state.created}} &emsp;&emsp;&emsp;
-    <b>Recipie:</b> {{state.recipe}} &emsp;&emsp;&emsp;
+    <b>Recipe:</b> {{state.recipe}} &emsp;&emsp;&emsp;
     <b>State:</b> {{state.state}}<br>
     <b>Message:</b><pre>{{state.state_message}}</pre>
     <br><br>

--- a/cnxpublishing/views/templates/content-status.html
+++ b/cnxpublishing/views/templates/content-status.html
@@ -1,0 +1,87 @@
+{% extends "base.html" %}
+{% block content %}
+  <h1>Content Status</h1>
+  <form action="/a/content-status/" method="get">
+    <b>Filters:</b><br>
+    Status: <br>
+      <label><input type="checkbox" name="pending_filter" {{PENDING}} value="PENDING">
+        PENDING
+        (<i class="fa fa-exclamation-triangle" style="font-size:20px;color:gold"></i>)
+      </label>&emsp;&emsp;&emsp;
+      <label><input type="checkbox" name="started_filter" {{STARTED}} value="STARTED">
+        STARTED
+        (<i class="fa fa-exclamation-triangle" style="font-size:20px;color:gold"></i>)
+      </label>&emsp;&emsp;&emsp;
+      <label><input type="checkbox" name="retry_filter" {{RETRY}} value="RETRY">
+        RETRY
+        (<i class="fa fa-close" style="font-size:20px;color:red"></i>)
+      </label>&emsp;&emsp;&emsp;
+      <label><input type="checkbox" name="failure_filter" {{FAILURE}} value="FAILURE">
+        FAILURE
+        (<i class="fa fa-close" style="font-size:20px;color:red"></i>)
+      </label>&emsp;&emsp;&emsp;
+      <label><input type="checkbox" name="success_filter" {{SUCCESS}} value="SUCCESS">
+        SUCCESS
+        (<i class="fa fa-check-square" style="font-size:20px;color:limeGreen"></i>)
+      </label>
+    <br><br>Author:
+      <input type="text" name="author" value={{author}}><br>
+    uuid:
+      <input type="text" name="uuid" value={{uuid}}><br>
+    Entries Per Page:  <input type="number" min="1" name="number" value={{num_entries}}><br>
+    Page:  <input type="number" min="1" name="page" value={{page}}><br>
+    <br>
+    <input type="submit" value="Filter"><br>
+  </form>
+  <br><br>
+  Showing {{start_entry + 1}} - {{start_entry + num_entries}} of {{total_entries}}
+  <br><br><br>
+
+  <table>
+    <tr>
+      <th onclick='sortBooks("bpsa.created")'>Created<i class="{{sort_created}}"></i></th>
+      <th onclick='sortBooks("m.name")'>Title<i class="{{sort_name}}"></i></th>
+      <th>Authors</th>
+      <th onclick='sortBooks("STATE")'>State<i class="{{sort_state}}"></i></th>
+      <th>Print Style</th>
+      <th>Recipe</th>
+      <th>Link to book</th>
+      <th>Message</th>
+    </tr>
+    {% for state in states %}
+      <tr>
+        <td>{{ state.created.strftime('%Y-%m-%d %H:%M:%S') }}</td>
+        <td>
+          <a href="{{ state.status_link }}">{{ state.title }}</a>
+        </td>
+        <td>{{ state.authors }}</td>
+        <td>
+          <i class="{{state.state_icon}}" style="{{state.state_icon_style}}"></i>{{ state.state }}
+        </td>
+        <td>{{ state.print_style }}</td>
+        <td>{{ state.recipie }}</td>
+        <td>
+          <a href='{{ state.content_link }}'>{{ state.content_link }}</a>
+        </td>
+        <td>{{ state.state_message }}</td>
+      </tr>
+    {% endfor %}
+  </table>
+{% endblock %}
+{% block script %}
+  function sortBooks(col) {
+    var new_link = "";
+    var current_url = window.location.href;
+    if (current_url.includes("sort=")) {
+      new_sort = current_url.includes("sort=" + col + "%20ASC")
+            ? "sort=" + col + " DESC"
+            : "sort=" + col + " ASC";
+      new_link = current_url.replace(/sort=[^&]*/, new_sort);
+    } else if (current_url.includes("/?")) { // no sort filter
+      new_link = current_url + "&sort=" + col + " ASC";
+    } else {  // no filters of any kind
+      new_link = current_url + "?sort=" + col + " ASC";
+    }
+    window.location.href = new_link;
+  }
+{% endblock %}

--- a/cnxpublishing/views/templates/content-status.html
+++ b/cnxpublishing/views/templates/content-status.html
@@ -59,9 +59,15 @@
           <i class="{{state.state_icon}}" style="{{state.state_icon_style}}"></i>{{ state.state }}
         </td>
         <td>{{ state.print_style }}</td>
-        <td>{{ state.recipie }}</td>
         <td>
-          <a href='{{ state.content_link }}'>{{ state.content_link }}</a>
+          {% if state.recipe %}
+          <a href="{{ state.recipe_link }}">{{ state.recipe }}</a>
+          {% else %}
+          None
+          {% endif %}
+        </td>
+        <td>
+          <a href="{{ state.content_link }}">{{ state.content_link }}</a>
         </td>
         <td>{{ state.state_message }}</td>
       </tr>

--- a/cnxpublishing/views/templates/content-status.html
+++ b/cnxpublishing/views/templates/content-status.html
@@ -43,7 +43,7 @@
       <th onclick='sortBooks("m.name")'>Title<i class="{{sort_name}}"></i></th>
       <th>Authors</th>
       <th onclick='sortBooks("STATE")'>State<i class="{{sort_state}}"></i></th>
-      <th>Print Style</th>
+      <th>Recipe Id</th>
       <th>Recipe</th>
       <th>Link to book</th>
       <th>Message</th>
@@ -58,7 +58,13 @@
         <td>
           <i class="{{state.state_icon}}" style="{{state.state_icon_style}}"></i>{{ state.state }}
         </td>
-        <td>{{ state.print_style }}</td>
+        <td>
+          {% if state.print_style %}
+          <a href={{ state.print_style_link }}>{{ state.print_style }}</a>
+          {% else %}
+          None
+          {% endif %}
+        </td>
         <td>
           {% if state.recipe %}
           <a href="{{ state.recipe_link }}">{{ state.recipe }}</a>

--- a/cnxpublishing/views/templates/print-style-single.html
+++ b/cnxpublishing/views/templates/print-style-single.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %}
+{% block content %}
+  <h1>Print Style: {{print_style}}</h1>
+  <p> Recipie type: {{recipe_type}} </p>
+  <p> Number of Books Using this Style: {{number}}</p>
+  <table>
+    <tr>
+      <th>Title</th>
+      <th>Authors</th>
+      <th>Status</th>
+      <th>Tag</th>
+      <th>Recipe</th>
+      <th>ident_hash</th>
+      <th>Revised</th>
+    </tr>
+    {% for collection in collections %}
+      <tr>
+        <td><a href={{collection.link}}>{{ collection.title }}<a></td>
+        <td>{{ collection.authors }}</td>
+        <td>{{ collection.status }}</td>
+        <td>{{ collection.tag }}</td>
+        <td>{{ collection.recipe }}</td>
+        <td>{{ collection.ident_hash }}</td>
+        <td>{{ collection.revised }}</td>
+      </tr>
+    {% endfor %}
+  </table>
+{% endblock %}

--- a/cnxpublishing/views/templates/print-style-single.html
+++ b/cnxpublishing/views/templates/print-style-single.html
@@ -15,12 +15,12 @@
     </tr>
     {% for collection in collections %}
       <tr>
-        <td><a href={{collection.link}}>{{ collection.title }}<a></td>
+        <td><a href={{collection.status_link}}>{{ collection.title }}</a></td>
         <td>{{ collection.authors }}</td>
         <td>{{ collection.status }}</td>
         <td>{{ collection.tag }}</td>
-        <td>{{ collection.recipe }}</td>
-        <td>{{ collection.ident_hash }}</td>
+        <td><a href={{ collection.recipe_link }}>{{ collection.recipe }}</a></td>
+        <td><a href={{ collection.link }}>{{ collection.ident_hash }}</a></td>
         <td>{{ collection.revised }}</td>
       </tr>
     {% endfor %}

--- a/cnxpublishing/views/templates/print-style.html
+++ b/cnxpublishing/views/templates/print-style.html
@@ -17,7 +17,7 @@
             <a href={{style.link}}>{{ style.print_style }}</a>
         </td>
         <td>{{ style.title }}</td>
-        <td>{{ style.number }}</td>
+        <td>{{ style.number }}{%if style.bad %} ({{ style.bad }}){% endif %}</td>
         <td>{{ style.tag }}</td>
         <td>{{ style.commit_id }}</td>
         <td>

--- a/cnxpublishing/views/templates/print-style.html
+++ b/cnxpublishing/views/templates/print-style.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+{% block content %}
+  <h1>Print Styles</h1>
+  <br>
+  <table>
+    <tr>
+      <th>Style</th>
+      <th>Number of Books</th>
+      <th>Type</th>
+      <th>Version</th>
+      <th>Time Stamp</th>
+    </tr>
+    {% for style in styles %}
+      <tr>
+        <td>
+          <a href={{style.link}}>{{ style.print_style }}</a>
+        </td>
+        <td>{{ style.number }}</td>
+        <td>{{ style.type }}</td>
+        <td>{{ style.tag }}</td>
+        <td>{{ style.revised }}</td>
+      </tr>
+    {% endfor %}
+  </table>
+{% endblock %}

--- a/cnxpublishing/views/templates/print-style.html
+++ b/cnxpublishing/views/templates/print-style.html
@@ -5,20 +5,27 @@
   <table>
     <tr>
       <th>Style</th>
-      <th>Number of Books</th>
-      <th>Type</th>
+      <th>Title</th>
+      <th>Books</th>
       <th>Version</th>
-      <th>Time Stamp</th>
+      <th>cnx-recipes commit</th>
+      <th>Deployed</th>
     </tr>
     {% for style in styles %}
       <tr>
         <td>
-          <a href={{style.link}}>{{ style.print_style }}</a>
+            <a href={{style.link}}>{{ style.print_style }}</a>
         </td>
+        <td>{{ style.title }}</td>
         <td>{{ style.number }}</td>
-        <td>{{ style.type }}</td>
         <td>{{ style.tag }}</td>
-        <td>{{ style.revised }}</td>
+        <td>{{ style.commit_id }}</td>
+        <td>
+        {% if style.revised %}
+          {{ style.revised.strftime('%Y-%m-%d %H:%M:%S') }}</td>
+        {% else %}
+          None
+        {% endif %}
       </tr>
     {% endfor %}
   </table>

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,9 +1,49 @@
+
 .. Use the following to start a new version entry:
 
    |version|
    ----------------------
 
    - feature message
+
+0.9.3
+-----
+
+- Explicitly close all psycopg2 db connections (#187)
+- Refactor and fix content-status view (#186)
+
+0.9.2
+-----
+
+- Check for a traceback when handling a celery task failure (#185)
+
+0.9.1
+-----
+
+- Make sure to reserve uuids for new composite content (#184)
+
+0.9.0
+-----
+
+- Use default icon for unknown states on content-status page (#182)
+- Fix to not error when no recipe is found (#180)
+- Optimize post publishing queue (#175)
+- Reword baking procedure log messages (#174)
+- Fix to add view templates to the package distribution (#169)
+- Allow content status pages to be publicly visible (#171)
+- Add views to view and inspect the content publication status (#161)
+- Add a workaround an issue with celery tests, which allows us
+  to unskip them (#170)
+- Fix tests by adding an empty ruleset file
+- Fix tests for change in bake() function signature
+- Fix to fetch recipe text durning baking
+- Use print-style to select recipe and fallback (#162)
+- Add admin page for managing site banner messages (#163)
+
+0.8.1
+-----
+
+- Check for a traceback when handling a celery task failure (#185)
 
 0.8.0
 -----

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     package_data={
-        'cnxpublishing': ['sql/*.sql', 'sql/*/*.sql', 'templates/*.*'],
+        'cnxpublishing': ['sql/*.sql', 'sql/*/*.sql', 'views/templates/*.*'],
         'cnxpublishing.tests': ['data/*.*'],
         },
     cmdclass=versioneer.get_cmdclass(),


### PR DESCRIPTION
Monitoring page with table that displays the print styles form the `print_style_recipes` table. Each print style can be clicked on and takes you to a page of all the books with that print_style. Each of those books then also links back to the content-status page for the baking history of that book (the page that is part of the other pr for the content status view)

The tests are commented out because of the celery globalization issue, and also because the test data doesn't have these tables filled in.