### PR TITLE
Set up travis to run on precise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: precise
 language: python
 # Note, /usr/bin/python is used because we must install to the system python
 # in order to make the package available to the plpython Postgres extension.


### PR DESCRIPTION
Travis is switching from Precise to Trusty as their default Linux environment.
For some reason, we are getting "InternalError: ImportError: No module named
cnxarchive.database" when our tests run on Trusty.

https://travis-ci.org/Connexions/cnx-publishing/builds/256197821

This change explicitly tells Travis to use Precise so that our tests will
continue to work while we look into the problem.