### PR TITLE
add tempaltes path to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     package_data={
-        'cnxpublishing': ['sql/*.sql', 'sql/*/*.sql', 'templates/*.*'],
+        'cnxpublishing': ['sql/*.sql', 'sql/*/*.sql', 'views/templates/*.*'],
         'cnxpublishing.tests': ['data/*.*'],
         },
     cmdclass=versioneer.get_cmdclass(),


### PR DESCRIPTION
added an extra path to package_data in setup.py so that when running serve the templates can be found

same as (https://github.com/Connexions/cnx-archive/pull/513)