### PR TITLE
Optimize post publishing queue

### DIFF
--- a/cnxpublishing/subscribers.py
+++ b/cnxpublishing/subscribers.py
@@ -30,6 +30,20 @@ def track_baking_proc_state(result, module_ident, cursor):
 def post_publication_processing(event, cursor):
     """Process post-publication events coming out of the database."""
     module_ident, ident_hash = event.module_ident, event.ident_hash
+
+    celery_app = get_current_registry().celery_app
+
+    # Check baking is not already queued.
+    cursor.execute('SELECT result_id::text '
+                   'FROM document_baking_result_associations '
+                   'WHERE module_ident = %s', (module_ident,))
+    for result in cursor.fetchall():
+        state = celery_app.AsyncResult(result[0]).state
+        if state in ('QUEUED', 'STARTED', 'RETRY'):
+            logger.debug('Already queued module_ident={} ident_hash={}'.format(
+                module_ident, ident_hash))
+            return
+
     logger.debug('Queued for processing module_ident={} ident_hash={}'.format(
         module_ident, ident_hash))
     update_module_state(cursor, module_ident, 'processing', None)
@@ -39,8 +53,9 @@ def post_publication_processing(event, cursor):
     # Start of task
     # FIXME Looking up the task isn't the most clear usage here.
     task_name = 'cnxpublishing.subscribers.baking_processor'
-    baking_processor = get_current_registry().celery_app.tasks[task_name]
+    baking_processor = celery_app.tasks[task_name]
     result = baking_processor.delay(module_ident, ident_hash)
+    baking_processor.backend.store_result(result.id, None, 'QUEUED')
 
     # Save the mapping between a celery task and this event.
     track_baking_proc_state(result, module_ident, cursor)

--- a/cnxpublishing/tasks.py
+++ b/cnxpublishing/tasks.py
@@ -11,6 +11,7 @@ from __future__ import absolute_import
 
 import celery
 import venusian
+from kombu import Queue
 from pyramid.scripting import prepare
 
 
@@ -69,6 +70,11 @@ def includeme(config):
         broker_url=settings['celery.broker'],
         result_backend=settings['celery.backend'],
         result_persistent=True,
+        task_default_queue='default',
+        task_queues=(
+            Queue('default'),
+            Queue('deferred'),
+        ),
     )
     # Override the existing Task class.
     config.registry.celery_app.Task = PyramidAwareTask

--- a/cnxpublishing/tests/test_subscribers.py
+++ b/cnxpublishing/tests/test_subscribers.py
@@ -43,7 +43,6 @@ def test_startup_event(db_cursor, complex_book_one,
 
 
 class TestPostPublicationProcessing(object):
-
     @pytest.fixture(autouse=True)
     def suite_fixture(self, scoped_pyramid_app, complex_book_one,
                       celery_worker):
@@ -253,3 +252,45 @@ class TestPostPublicationProcessing(object):
         result2.get()  # blocking operation
         assert result2.state == 'SUCCESS'
         assert mock_bake.call_count == 2
+
+    def test_priority(self, db_cursor, mocker, complex_book_one_v2):
+        from celery.exceptions import Retry
+
+        mock_retry = mocker.patch('celery.app.task.Task.retry')
+        mock_retry.return_value = Exception('Task can be retried')
+
+        binder_v2, ident_mapping = complex_book_one_v2
+        mock_bake = mocker.patch('cnxpublishing.subscribers.bake')
+        binder_v2_module_ident = ident_mapping[binder_v2.ident_hash]
+
+        db_cursor.execute("select array_agg(uuid) from modules where portal_type = 'Collection'")
+
+        # Create the post publication event for complex book one
+        event1 = self.make_event()
+
+        # Create the post publication event for complex book one v2
+        event2 = self.make_event(payload=self.make_payload(
+            module_ident=binder_v2_module_ident,
+            ident_hash=binder_v2.ident_hash))
+
+        self.target(event1)
+        self.target(event2)
+
+        db_cursor.execute("SELECT module_ident, result_id::text "
+                          "FROM document_baking_result_associations "
+                          "WHERE module_ident IN %s",
+                          ((self.module_ident, binder_v2_module_ident),))
+        result_ids = dict(db_cursor.fetchall())
+
+        from celery.result import AsyncResult
+        result1 = AsyncResult(id=result_ids[self.module_ident])
+        with pytest.raises(Exception) as exc_info:
+            result1.get()  # blocking operation
+            assert str(exc_info.exception) == 'Task can be retried'
+            assert mock_retry.call_args_list == [((), {'queue': 'deferred'})]
+
+        result2 = AsyncResult(id=result_ids[binder_v2_module_ident])
+        result2.get()  # blocking operation
+
+        assert mock_bake.call_count == 1
+        assert mock_bake.call_args[0][0].ident_hash == binder_v2.ident_hash

--- a/cnxpublishing/tests/use_cases.py
+++ b/cnxpublishing/tests/use_cases.py
@@ -927,6 +927,31 @@ def setup_COMPLEX_BOOK_ONE_in_archive(test_case, cursor):
     return model
 
 
+def setup_COMPLEX_BOOK_ONE_v2_in_archive(test_case, cursor):
+    """Set up COMPLEX_BOOK_ONE v2"""
+    model = deepcopy(COMPLEX_BOOK_ONE)
+
+    publisher = 'ream'
+    publication_message = 'published via test setup'
+    # FIXME Use the REVISED_* id when it exists.
+    model.id = 'c3bb4bfb-3b53-41a9-bb03-583cf9ce3408'
+    model.metadata['version'] = '2.1'
+
+    doc = setup_PAGE_ONE_in_archive(test_case, cursor)
+    model[0][0] = doc
+    doc = setup_PAGE_TWO_in_archive(test_case, cursor)
+    model[0][1] = doc
+    doc = setup_PAGE_THREE_in_archive(test_case, cursor)
+    model[1][0] = doc
+    del model[1][1]
+
+    from ..publish import publish_model
+    if not _is_published(model.ident_hash, cursor):
+        publish_model(cursor, model, publisher, publication_message)
+    _set_uri(model)
+    return model
+
+
 def setup_COMPLEX_BOOK_TWO_in_archive(test_case, cursor):
     """Set up COMPLEX_BOOK_ONE"""
     model = deepcopy(COMPLEX_BOOK_TWO)


### PR DESCRIPTION
- Avoid duplicate items in post publishing queue
- Send non latest bake requests to the deferred queue