### PR TITLE
Use cnx-db docker image on travis

### DIFF
--- a/.travis-compose.yml
+++ b/.travis-compose.yml
@@ -1,0 +1,9 @@
+version: "2"
+services:
+  db:
+    build: https://github.com/Connexions/cnx-db.git
+    ports:
+      - "5432:5432"
+    environment:
+      - DB_USER=cnxarchive
+      - DB_NAME=cnxarchive-testing

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
-dist: precise
+dist: trusty
+sudo: required
 language: python
 # Note, /usr/bin/python is used because we must install to the system python
 # in order to make the package available to the plpython Postgres extension.
 python:
   - "2.7"
-addons:
-  postgresql: "9.4"
 services:
   - rabbitmq
+  - docker
 before_install:
   - pip install pep8
   - pep8 --exclude=tests *.py cnxpublishing/
@@ -16,21 +16,18 @@ before_install:
   - sudo apt-get update
   # remove zope.interface installed from aptitude
   - sudo apt-get purge python-zope.interface
-  # Install the 'plpython' extension language
+
+  # Stop local postgres
+  - sudo service postgresql stop
+
+  # Create cnx-db docker image
+  - docker-compose -f .travis-compose.yml up -d
 
   # Installation for cnx-archive:
-  # * Install the 'plpython' extension language
-  - sudo apt-get install postgresql-plpython-9.4
-  # * Install the 'plxslt' extension language
-  - sudo apt-get install libxml2-dev libxslt-dev postgresql-server-dev-9.4
-  - git clone https://github.com/petere/plxslt.git
-  - cd plxslt && sudo make && sudo make install && cd ..
   # * Install cnx-query-grammar
-  - git clone https://github.com/Connexions/cnx-query-grammar.git
-  - cd cnx-query-grammar && python setup.py install && cd ..
+  - pip install git+https://github.com/Connexions/cnx-query-grammar.git#egg=cnx-query-grammar
   # * Install rhaptos.cnxmlutils
-  - git clone https://github.com/Connexions/rhaptos.cnxmlutils.git
-  - cd rhaptos.cnxmlutils && python setup.py install && cd ..
+  - pip install git+https://github.com/Connexions/rhaptos.cnxmlutils.git#egg=cnx-rhaptos.cnxmlutils
 
   # Installation for cnx-publishing
   # Install cssselect2 (unreleased), required by cnx-easybake
@@ -38,33 +35,25 @@ before_install:
   # Install cnx-easybake
   - pip install git+https://github.com/Connexions/cnx-easybake.git#egg=cnx-easybake
   # * Install cnx-epub
-  - git clone https://github.com/Connexions/cnx-epub.git
-  - cd cnx-epub && python setup.py install && cd ..
-
-  # * Install cnx-archive
-  - git clone https://github.com/Connexions/cnx-archive.git
-  - cd cnx-archive && python setup.py install && cd ..
+  - pip install git+https://github.com/Connexions/cnx-epub.git#egg=cnx-epub
   # * Install cnx-db
-  - git clone https://github.com/Connexions/cnx-db.git
-  - cd cnx-db && python setup.py install && cd ..
+  - pip install git+https://github.com/Connexions/cnx-db.git#egg=cnx-db
+  # * Install cnx-archive
+  - pip install git+https://github.com/Connexions/cnx-archive.git#egg=cnx-archive
   # Install the coverage utility and codecov reporting utility
   - pip install coverage
   - pip install codecov
 install:
   - pip install ".[test]"
 before_script:
-  # Set up postgres roles
-  - sudo -u postgres psql -d postgres -c "CREATE USER cnxarchive WITH SUPERUSER PASSWORD 'cnxarchive';"
-  # Set up the database
-  - sudo -u postgres createdb -O cnxarchive cnxarchive-testing
-  - git clone https://github.com/okbob/session_exec
-  - cd session_exec
-  - make USE_PGXS=1 -e && sudo make USE_PGXS=1 -e install
-  - cd ..
+  # Give cnxarchive superuser privileges on postgres
+  - docker exec cnxpublishing_db_1 /bin/bash -c "echo 'ALTER USER cnxarchive WITH SUPERUSER' | psql -U postgres postgres"
+  # Stop init_venv from doing anything
+  - docker exec cnxpublishing_db_1 /bin/bash -c "echo 'CREATE SCHEMA venv' | psql -U cnxarchive cnxarchive-testing"
   - pip install -U pytest pytest-runner pytest-cov
 script:
   # This is the same as `coverage run setup.py test`.
-  - pytest cnxpublishing
+  - AS_VENV_IMPORTABLE=false pytest cnxpublishing
 after_success:
   # Report test coverage to codecov.io
   - codecov

--- a/cnxpublishing/tests/test_db.py
+++ b/cnxpublishing/tests/test_db.py
@@ -19,12 +19,11 @@ except ImportError:
 
 import psycopg2
 import cnxepub
-from cnxdb.init import init_db
 from pyramid import testing
 
 from ..utils import join_ident_hash, split_ident_hash
 from . import use_cases
-from .testing import db_connect, integration_test_settings
+from .testing import db_connect, integration_test_settings, init_db
 
 
 VALID_LICENSE_URL = "http://creativecommons.org/licenses/by/4.0/"
@@ -71,7 +70,7 @@ class BaseDatabaseIntegrationTestCase(unittest.TestCase):
             cls._tear_down_database()
 
     def setUp(self):
-        init_db(self.db_conn_str, True)
+        init_db(self.db_conn_str)
 
         # Declare a request, so that we can use the route generator methods.
         request = testing.DummyRequest()

--- a/cnxpublishing/tests/test_publish.py
+++ b/cnxpublishing/tests/test_publish.py
@@ -18,7 +18,6 @@ except ImportError:
 import cnxepub
 import psycopg2
 from cnxarchive.utils import join_ident_hash
-from cnxdb.init import init_db
 from webob import Request
 from pyramid import testing
 
@@ -28,6 +27,7 @@ from .testing import (
     integration_test_settings,
     db_connection_factory,
     db_connect,
+    init_db,
     )
 from .test_db import BaseDatabaseIntegrationTestCase
 
@@ -62,7 +62,7 @@ class PublishIntegrationTestCase(unittest.TestCase):
         cls.db_connect = staticmethod(db_connection_factory())
 
     def setUp(self):
-        init_db(self.db_conn_str, True)
+        init_db(self.db_conn_str)
         self.config = testing.setUp(settings=self.settings)
 
     def tearDown(self):
@@ -471,7 +471,7 @@ class RepublishTestCase(unittest.TestCase):
         cls.db_conn_str = cls.settings[CONNECTION_STRING]
 
     def setUp(self):
-        init_db(self.db_conn_str, True)
+        init_db(self.db_conn_str)
         self.config = testing.setUp(settings=self.settings)
 
     def tearDown(self):

--- a/cnxpublishing/tests/testing.py
+++ b/cnxpublishing/tests/testing.py
@@ -9,6 +9,7 @@ import os
 import functools
 
 import psycopg2
+from cnxdb.init import init_db as _init_db
 from pyramid.paster import get_appsettings
 
 
@@ -65,3 +66,8 @@ def db_connect(method):
             with db_connection.cursor() as cursor:
                 return method(self, cursor, *args, **kwargs)
     return wrapped
+
+
+def init_db(db_conn_str):
+    venv = os.getenv('AS_VENV_IMPORTABLE', 'true').lower() == 'true'
+    _init_db(db_conn_str, venv)

--- a/cnxpublishing/tests/views/base.py
+++ b/cnxpublishing/tests/views/base.py
@@ -12,13 +12,13 @@ import unittest
 import zipfile
 
 import cnxepub
-from cnxdb.init import init_db
 from webtest import TestApp
 from pyramid import testing
 
 from ..testing import (
     integration_test_settings,
     db_connection_factory,
+    init_db,
     )
 
 
@@ -135,7 +135,7 @@ class BaseFunctionalViewTestCase(unittest.TestCase, EPUBMixInTestCase):
     def setUp(self):
         EPUBMixInTestCase.setUp(self)
         config = testing.setUp(settings=self.settings)
-        init_db(self.db_conn_str, True)
+        init_db(self.db_conn_str)
 
         # Assign API keys for testing
         self.set_up_api_keys()

--- a/cnxpublishing/tests/views/test_admin.py
+++ b/cnxpublishing/tests/views/test_admin.py
@@ -10,7 +10,6 @@ import unittest
 
 from datetime import datetime
 
-from cnxdb.init import init_db
 from pyramid import testing
 import pytest
 import psycopg2
@@ -20,6 +19,7 @@ from .. import use_cases
 from ..testing import (
     integration_test_settings,
     db_connection_factory,
+    init_db,
     )
 
 
@@ -104,7 +104,7 @@ class SiteMessageViewsTestCase(unittest.TestCase):
 
     def setUp(self):
         self.config = testing.setUp(settings=self.settings)
-        init_db(self.db_conn_str, True)
+        init_db(self.db_conn_str)
         self.create_post_args = {
             'message': 'test message',
             'priority': 1,

--- a/cnxpublishing/tests/views/test_api_keys.py
+++ b/cnxpublishing/tests/views/test_api_keys.py
@@ -7,12 +7,12 @@
 # ###
 import unittest
 
-from cnxdb.init import init_db
 from pyramid import testing
 
 from ..testing import (
     integration_test_settings,
     db_connection_factory,
+    init_db,
     )
 
 
@@ -31,7 +31,7 @@ class ApiKeyViewsTestCase(unittest.TestCase):
 
     def setUp(self):
         self.config = testing.setUp(settings=self.settings)
-        init_db(self.db_conn_str, True)
+        init_db(self.db_conn_str)
 
     def tearDown(self):
         with self.db_connect() as db_conn:


### PR DESCRIPTION
On travis trusty, the default Linux environment, postgres is probably
running in a different server. It was not able to see the files in
/home/travis/virtualenv/python2.7.13, which is where our source code is
checked out on travis.

Towards #168