### PR TITLE
No error if no recipe at all is found

### DIFF
--- a/cnxpublishing/subscribers.py
+++ b/cnxpublishing/subscribers.py
@@ -118,6 +118,18 @@ to the deferred (low priority) queue"""
 
     logger.debug('Starting baking module_ident={} ident_hash={}'
                  .format(module_ident, ident_hash))
+
+    recipe_ids = _get_recipe_ids(module_ident, cursor)
+
+    state = 'current'
+    if recipe_ids == (None, None):
+        remove_baked(ident_hash, cursor=cursor)
+        logger.debug('Finished unbaking module_ident={} ident_hash={} '
+                     'with a final state of \'{}\'.'
+                     .format(module_ident, ident_hash, state))
+        update_module_state(cursor, module_ident, state, None)
+        return
+
     try:
         binder = export_epub.factory(ident_hash)
     except:
@@ -137,15 +149,6 @@ WHERE ident_hash(uuid, major_version, minor_version) = %s""",
                    (ident_hash,))
     publisher, message = cursor.fetchone()
     remove_baked(ident_hash, cursor=cursor)
-
-    recipe_ids = _get_recipe_ids(module_ident, cursor)
-
-    state = 'current'
-    if recipe_ids[0] is None and recipe_ids[1] is None:
-        logger.debug('Finished unbaking module_ident={} ident_hash={} '
-                     'with a final state of \'{}\'.'
-                     .format(module_ident, ident_hash, state))
-        update_module_state(cursor, module_ident, state, None)
 
     for recipe_id in recipe_ids:
         try:

--- a/cnxpublishing/subscribers.py
+++ b/cnxpublishing/subscribers.py
@@ -141,6 +141,12 @@ WHERE ident_hash(uuid, major_version, minor_version) = %s""",
     recipe_ids = _get_recipe_ids(module_ident, cursor)
 
     state = 'current'
+    if recipe_ids[0] is None and recipe_ids[1] is None:
+        logger.debug('Finished unbaking module_ident={} ident_hash={} '
+                     'with a final state of \'{}\'.'
+                     .format(module_ident, ident_hash, state))
+        update_module_state(cursor, module_ident, state, None)
+
     for recipe_id in recipe_ids:
         try:
             bake(binder, recipe_id, publisher, message, cursor=cursor)


### PR DESCRIPTION
Current code passes the None on down through the pipeline, eventually erroring on trying to fetch the bits from a null result from the database. This bypasses baking if the recipe id is not found, eventually storing a "Current" with a null recipe i.e. unbaked.