### PR TITLE
Use default icon for unknown states on content-status page

### DIFF
--- a/cnxpublishing/views/admin.py
+++ b/cnxpublishing/views/admin.py
@@ -27,10 +27,11 @@ STATE_ICONS = {
                 'style': 'font-size:20px;color:gold'},
     "PENDING": {'class': 'fa fa-exclamation-triangle',
                 'style': 'font-size:20px;color:gold'},
-    "RETRY": {'class': 'a fa-close',
+    "RETRY": {'class': 'fa fa-close',
               'style': 'font-size:20px;color:red'},
     "FAILURE": {'class': 'fa fa-close',
                 'style': 'font-size:20px;color:red'}}
+DEFAULT_ICON = STATE_ICONS['PENDING']
 SORTS_DICT = {
     "bpsa.created": 'created',
     "m.name": 'name',
@@ -404,8 +405,10 @@ def admin_content_status(request):
                     'created': row[-2],
                     'state': state,
                     'state_message': message,
-                    'state_icon': STATE_ICONS[state_icon]['class'],
-                    'state_icon_style': STATE_ICONS[state_icon]['style'],
+                    'state_icon': STATE_ICONS.get(
+                        state_icon, DEFAULT_ICON)['class'],
+                    'state_icon_style': STATE_ICONS.get(
+                        state_icon, DEFAULT_ICON)['style'],
                     'status_link': request.route_path(
                         'admin-content-status-single', uuid=row[2]),
                     'content_link': request.route_path(


### PR DESCRIPTION
We recently added a `QUEUED` state as part of the optimization for the
post publication queue.  This caused an error on the content-status
page:

```
2017-09-19 10:57:23,190 ERROR [waitress][waitress] Exception when serving /a/content-status/
Traceback (most recent call last):
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/waitress/channel.py", line 338, in service
    task.service()
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/waitress/task.py", line 169, in service
    self.execute()
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/waitress/task.py", line 399, in execute
    app_iter = self.channel.server.application(env, start_response)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/paste/deploy/config.py", line 291, in __call__
    return self.app(environ, start_response)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/pyramid/router.py", line 233, in __call__
    response = self.invoke_subrequest(request, use_tweens=True)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/pyramid/router.py", line 208, in invoke_subrequest
    response = handle_request(request)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/pyramid_sawing/main.py", line 39, in __call__
    response = self.handler(request)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/pyramid/tweens.py", line 62, in excview_tween
    reraise(*attrs['exc_info'])
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/pyramid/tweens.py", line 22, in excview_tween
    response = handler(request)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/pyramid/router.py", line 155, in handle_request
    view_name
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/pyramid/view.py", line 612, in _call_view
    response = view_callable(context, request)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/pyramid/viewderivers.py", line 389, in attr_view
    return view(context, request)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/pyramid/viewderivers.py", line 367, in predicate_wrapper
    return view(context, request)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/pyramid/viewderivers.py", line 300, in secured_view
    return view(context, request)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/pyramid/viewderivers.py", line 438, in rendered_view
    result = view(context, request)
  File "/var/cnx/venvs/publishing/local/lib/python2.7/site-packages/pyramid/viewderivers.py", line 147, in _requestonly_view
    response = view(request)
  File "/var/cnx/venvs/publishing/src/cnx-publishing/cnxpublishing/views/admin.py", line 407, in admin_content_status
    'state_icon': STATE_ICONS[state_icon]['class'],
KeyError: u'QUEUED'
```

To avoid having this problem again, we are going to add a DEFAULT_ICON and use
it whenever states are not found in the STATE_ICONS.

Close #181