### PR TITLE
make sure to reserve uuids for new composite objects

### DIFF
--- a/cnxpublishing/publish.py
+++ b/cnxpublishing/publish.py
@@ -184,6 +184,15 @@ def _insert_metadata(cursor, model, publisher, message):
             moduleid = None
         params['_moduleid'] = moduleid
 
+        # Verify that uuid is reserved in document_contols. If not, add it.
+        cursor.execute("SELECT * from document_controls where uuid = %s",
+                       (uuid,))
+        try:
+            _ = cursor.fetchone()[0]
+        except TypeError as exc:  # NoneType
+            cursor.execute("INSERT INTO document_controls (uuid) VALUES (%s)",
+                           (uuid,))
+
         created = model.metadata.get('created', None)
         # Format the statement to accept the identifiers.
         stmt = MODULE_INSERTION_TEMPLATE.format(**{


### PR DESCRIPTION
Hopefully this will at least get in the way of the duplicate uuids. However, my testing on QA does not seem to jusify such optimism: I had-inserted all existing uuids, but publishing collections is _still_ making dups.