### PR TITLE
Explicitly close all psycopg2 db connections

### DIFF
--- a/cnxpublishing/tests/views/test_admin.py
+++ b/cnxpublishing/tests/views/test_admin.py
@@ -340,8 +340,8 @@ class ContentStatusViewsTestCase(unittest.TestCase):
         self.assertIn('invalid page', caught_exc.exception.message)
 
     @mock.patch('cnxpublishing.views.admin.AsyncResult')
-    @mock.patch('psycopg2.connect')
-    def test_admin_content_status_state_icons(self, mock_psycopg2_connect,
+    @mock.patch('cnxpublishing.views.admin.db_connect')
+    def test_admin_content_status_state_icons(self, mock_db_connect,
                                               mock_async_result):
         states = ['PENDING', 'QUEUED', 'STARTED', 'RETRY', 'SUCCESS',
                   'FAILURE', 'REVOKED', 'UNKNOWN']
@@ -372,7 +372,7 @@ class ContentStatusViewsTestCase(unittest.TestCase):
              'result_id': 'result-{}'.format(i)}
             for i in range(len(states))]
 
-        db_conn = mock_psycopg2_connect.return_value.__enter__()
+        db_conn = mock_db_connect.return_value.__enter__()
         db_conn.cursor().__enter__.return_value = cursor
 
         request = testing.DummyRequest()

--- a/cnxpublishing/views/api_keys.py
+++ b/cnxpublishing/views/api_keys.py
@@ -5,10 +5,9 @@
 # Public License version 3 (AGPLv3).
 # See LICENCE.txt for details.
 # ###
-import psycopg2
 from pyramid.view import view_config
 
-from .. import config
+from ..db import db_connect
 
 
 @view_config(route_name='api-keys', request_method='GET',
@@ -16,9 +15,7 @@ from .. import config
              renderer='json', permission='administer')
 def get_api_keys(request):
     """Return the list of API keys."""
-    settings = request.registry.settings
-
-    with psycopg2.connect(settings[config.CONNECTION_STRING]) as db_conn:
+    with db_connect() as db_conn:
         with db_conn.cursor() as cursor:
             cursor.execute("""\
 SELECT row_to_json(combined_rows) FROM (


### PR DESCRIPTION
The psycopg2 db connection `with` statement does not actually close the
database connection causing lots of idle postgres connections on the
production servers.  An idle postgres connection can be found by doing
`ps aux` on the database servers, for example you will see something
like this:

```
postgres 25498  0.0  0.5 302652 10996 ?        Ss   09:31   0:00 postgres: cnxarchive cnxarchive 192.168.122.250(42646) idle
```

On http://initd.org/psycopg/docs/usage.html#with-statement

"Note that, unlike file objects or other resources, exiting the
connection’s with block doesn't close the connection but only the
transaction associated with it"

This change creates a `db_connect` function that is like
`psycopg2.connect` but closes the db connection when exiting the `with`
block.