### PR TITLE
Move static directory from `/static` to `/a/static`

### DIFF
--- a/cnxpublishing/views/__init__.py
+++ b/cnxpublishing/views/__init__.py
@@ -65,7 +65,7 @@ def includeme(config):
     config.include('pyramid_jinja2')
     config.add_jinja2_renderer('.html')
     config.add_jinja2_renderer('.rss')
-    config.add_static_view(name='static', path="cnxpublishing:static/")
+    config.add_static_view(name='/a/static', path="cnxpublishing:static/")
 
     # Commit the configuration otherwise the jija2_env won't have
     # a `globals` assignment.

--- a/cnxpublishing/views/templates/base.html
+++ b/cnxpublishing/views/templates/base.html
@@ -7,10 +7,10 @@
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <link rel="stylesheet" href="/static/css/normalize.min.css">
-    <link rel="stylesheet" href="/static/css/main.css">
+    <link rel="stylesheet" href="{{ request.static_url('cnxpublishing:static/css/normalize.min.css') }}">
+    <link rel="stylesheet" href="{{ request.static_url('cnxpublishing:static/css/main.css') }}">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
-    <script src="/static/js/vendor/modernizr-2.8.3.min.js"></script>
+    <script src="{{ request.static_url('cnxpublishing:static/js/vendor/modernizr-2.8.3.min.js') }}"></script>
     {% block head %}
     {% endblock %}
   </head>
@@ -21,10 +21,10 @@
     </div>
 
     <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
-    <script>window.jQuery || document.write('<script src="/static/js/vendor/jquery-1.11.2.min.js"><\/script>')</script>
+    <script>window.jQuery || document.write('<script src="' + "{{ request.static_url('cnxpublishing:static/js/vendor/jquery-1.11.2.min.js') }}" + '"><\/script>')</script>
 
-    <script src="/static/js/plugins.js"></script>
-    <script src="/static/js/main.js"></script>
+    <script src="{{ request.static_url('cnxpublishing:static/js/plugins.js') }}"></script>
+    <script src="{{ request.static_url('cnxpublishing:static/js/main.js') }}"></script>
     <script>
       {% block script %}
       {% endblock %}


### PR DESCRIPTION
This is the path we decided to use for publishing admin views static
files like javascript and css files.  The reason is `/static` is too
generic and we might need it for webview or archive later.