### PR TITLE
Print style view

### DIFF
--- a/cnxpublishing/subscribers.py
+++ b/cnxpublishing/subscribers.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
 import logging
 
 from cnxarchive.scripts import export_epub
@@ -46,7 +48,8 @@ def post_publication_processing(event, cursor):
 
     logger.debug('Queued for processing module_ident={} ident_hash={}'.format(
         module_ident, ident_hash))
-    update_module_state(cursor, module_ident, 'processing', None)
+    recipe_ids = _get_recipe_ids(module_ident, cursor)
+    update_module_state(cursor, module_ident, 'processing', recipe_ids[0])
     # Commit the state change before preceding.
     cursor.connection.commit()
 
@@ -164,7 +167,7 @@ WHERE ident_hash(uuid, major_version, minor_version) = %s""",
                 logger.exception('Uncaught exception during baking')
                 update_module_state(cursor, module_ident, state, recipe_id)
                 raise
-        finally:
+        else:
             logger.debug('Finished baking module_ident={} ident_hash={} '
                          'with a final state of \'{}\'.'
                          .format(module_ident, ident_hash, state))

--- a/cnxpublishing/tests/views/test_admin.py
+++ b/cnxpublishing/tests/views/test_admin.py
@@ -110,12 +110,7 @@ class PrintStyleViewsTestCase(unittest.TestCase):
     def setUp(self):
         self.config = testing.setUp(settings=self.settings)
         self.config.include('cnxpublishing.tasks')
-        self.config.add_route('get-content', '/contents/{ident_hash}')
-        self.config.add_route('admin-content-status-single',
-                              '/a/content-status/{uuid}')
-        self.config.add_route('admin-print-style-single',
-                              '/a/print-style/{style}')
-        self.config.add_route('get-resource', '/resources/{hash}')
+        self.config.include('cnxpublishing.views')
         init_db(self.db_conn_str)
         with self.db_connect() as db_conn:
             with db_conn.cursor() as cursor:
@@ -340,12 +335,7 @@ class ContentStatusViewsTestCase(unittest.TestCase):
     def setUp(self):
         self.config = testing.setUp(settings=self.settings)
         self.config.include('cnxpublishing.tasks')
-        self.config.add_route('admin-content-status-single',
-                              '/a/content-status/{uuid}')
-        self.config.add_route('admin-print-style-single',
-                              '/a/print-style/{style}')
-        self.config.add_route('get-content', '/contents/{ident_hash}')
-        self.config.add_route('get-resource', '/resources/{hash}')
+        self.config.include('cnxpublishing.views')
 
         add_data(self)
 

--- a/cnxpublishing/tests/views/test_admin.py
+++ b/cnxpublishing/tests/views/test_admin.py
@@ -364,6 +364,7 @@ class ContentStatusViewsTestCase(unittest.TestCase):
             'status_filters': ['QUEUED', 'STARTED', 'RETRY',
                                'FAILURE', 'SUCCESS'],
             'domain': 'example.com:80',
+            'latest_only': False,
             'start_entry': 0,
             'page': 1,
             'num_entries': 100,
@@ -396,6 +397,7 @@ class ContentStatusViewsTestCase(unittest.TestCase):
                 ('SUCCESS', 'fa fa-check-square state-icon success')],
             'status_filters': ['PENDING'],
             'domain': 'example.com:80',
+            'latest_only': False,
             'start_entry': 0,
             'page': 1,
             'num_entries': 2,
@@ -428,10 +430,10 @@ class ContentStatusViewsTestCase(unittest.TestCase):
             ]))
         from ...views.admin import admin_content_status
         content = admin_content_status(request)
-        self.assertEqual('PENDING stale_content',
+        self.assertEqual('PENDING',
                          content['states'][0]['state'])
         self.assertEqual('(custom)',
-                         content['states'][0]['print_style'])
+                         content['states'][0]['recipe_name'])
         self.assertEqual('8d539366a39af1715bdf4154d0907d4a5360ba29',
                          content['states'][0]['recipe'])
 
@@ -478,7 +480,9 @@ class ContentStatusViewsTestCase(unittest.TestCase):
              'print_style': 'print-style',
              'latest_recipe_id': 'latest-recipe',
              'recipe_id': 'latest-recipe',
+             'recipe_name': 'the-latest-recipe',
              'recipe': '093979b0ca430454e4a1dedb409f186b66c7494e',
+             'recipe_tag': 'v0.0.1',
              'latest_version': '1.1',
              'current_version': '1.1',
              'module_ident': 'm0000',
@@ -523,17 +527,17 @@ class ContentStatusViewsTestCase(unittest.TestCase):
             'print_style': None,
             'current_recipe': None,
             'current_ident': 2,
-            'current_state': u'PENDING stale_content',
+            'current_state': u'PENDING',
             'states': [
                 {'version': '1.1',
                  'recipe': None,
                  'created': content['states'][0]['created'],
-                 'state': 'PENDING stale_content',
+                 'state': 'PENDING',
                  'state_message': ''},
                 {'version': '1.1',
                  'recipe': None,
                  'created': content['states'][1]['created'],
-                 'state': 'PENDING stale_content',
+                 'state': 'PENDING',
                  'state_message': ''}
             ]
         }, content)
@@ -580,7 +584,7 @@ class ContentStatusViewsTestCase(unittest.TestCase):
                        'number': 1}
         content = admin_content_status_single(request)
         print [x['state'] for x in content['states']]
-        self.assertEqual('PENDING stale_content',
+        self.assertEqual('PENDING',
                          content['states'][0]['state'])
 
     def test_admin_content_status_single_page_POST_already_baking(self):

--- a/cnxpublishing/tests/views/test_admin.py
+++ b/cnxpublishing/tests/views/test_admin.py
@@ -428,8 +428,12 @@ class ContentStatusViewsTestCase(unittest.TestCase):
             ]))
         from ...views.admin import admin_content_status
         content = admin_content_status(request)
-        self.assertEqual('PENDING stale_content stale_recipe',
+        self.assertEqual('PENDING stale_content',
                          content['states'][0]['state'])
+        self.assertEqual('(custom)',
+                         content['states'][0]['print_style'])
+        self.assertEqual('8d539366a39af1715bdf4154d0907d4a5360ba29',
+                         content['states'][0]['recipe'])
 
     def test_admin_content_status_bad_sort(self):
         request = testing.DummyRequest()
@@ -574,7 +578,6 @@ class ContentStatusViewsTestCase(unittest.TestCase):
 
         request.GET = {'page': 1,
                        'number': 1}
-        from ...views.admin import admin_content_status
         content = admin_content_status_single(request)
         print [x['state'] for x in content['states']]
         self.assertEqual('PENDING stale_content',
@@ -629,5 +632,5 @@ class ContentStatusViewsTestCase(unittest.TestCase):
         uuid = 'd5dbbd8e-d137-4f89-9d0a-eeeeeeeeeeee'
         request.matchdict['uuid'] = uuid
         with self.assertRaises(HTTPBadRequest) as caught_exc:
-            content = admin_content_status_single_POST(request)
+            _content = admin_content_status_single_POST(request)  # noqa
         self.assertIn('not a book', caught_exc.exception.message)

--- a/cnxpublishing/tests/views/test_admin.py
+++ b/cnxpublishing/tests/views/test_admin.py
@@ -17,7 +17,7 @@ from datetime import datetime
 
 from pyramid import testing
 import psycopg2
-from pyramid.httpexceptions import HTTPBadRequest
+from pyramid.httpexceptions import HTTPBadRequest, HTTPNotFound
 from webob.multidict import MultiDict
 
 from .. import use_cases
@@ -95,6 +95,101 @@ class PostPublicationsViewsTestCase(unittest.TestCase):
                  'state_message': '',
                  'title': 'Book of Infinity'},
                 ]}, resp_data)
+
+
+class PrintStyleViewsTestCase(unittest.TestCase):
+    maxDiff = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.settings = integration_test_settings()
+        from cnxpublishing.config import CONNECTION_STRING
+        cls.db_conn_str = cls.settings[CONNECTION_STRING]
+        cls.db_connect = staticmethod(db_connection_factory())
+
+    def setUp(self):
+        self.config = testing.setUp(settings=self.settings)
+        self.config.include('cnxpublishing.tasks')
+        self.config.add_route('get-content', '/contents/{ident_hash}')
+        self.config.add_route('admin-content-status-single',
+                              '/a/content-status/{uuid}')
+        self.config.add_route('admin-print-style-single',
+                              '/a/print-style/{style}')
+        self.config.add_route('get-resource', '/resources/{hash}')
+        init_db(self.db_conn_str)
+        with self.db_connect() as db_conn:
+            with db_conn.cursor() as cursor:
+                cursor.execute("""INSERT INTO files
+                                  (file, media_type) VALUES ('file', 'css');""")
+                cursor.execute("""INSERT INTO print_style_recipes
+                                  (print_style, title, fileid, tag)
+                                  VALUES ('ccap-physics', 'CCAP Physics', 1, '1.0');""")
+
+    def tearDown(self):
+        with self.db_connect() as db_conn:
+            with db_conn.cursor() as cursor:
+                cursor.execute("DROP SCHEMA public CASCADE")
+                cursor.execute("CREATE SCHEMA public")
+        testing.tearDown()
+
+    def test_print_styles(self):
+        request = testing.DummyRequest()
+
+        from ...views.admin import admin_print_styles
+        content = admin_print_styles(request)
+        self.assertEqual(1, len(content['styles']))
+        self.assertEqual(content['styles'][0],
+                         {'print_style': 'ccap-physics',
+                          'type': 'web',
+                          'revised': content['styles'][0]['revised'],
+                          'number': 0,
+                          'bad': 0,
+                          'commit_id': None,
+                          'title': 'CCAP Physics',
+                          'tag': '1.0',
+                          'link': '/a/print-style/ccap-physics'})
+
+    def test_print_style_single(self):
+        request = testing.DummyRequest()
+        with self.db_connect() as db_conn:
+            with db_conn.cursor() as cursor:
+                cursor.execute("""INSERT INTO modules
+                                  (print_style, portal_type, name, licenseid,
+                                        doctype, uuid, created, revised, recipe)
+                                  VALUES ('ccap-physics', 'Collection', 'test', 1,
+                                        'doc', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', now(), now(), 1);""")
+
+        print_style = 'ccap-physics'
+        request.matchdict['style'] = print_style
+
+        from ...views.admin import admin_print_styles_single
+        content = admin_print_styles_single(request)
+        self.assertEqual(content['print_style'], 'ccap-physics')
+        self.assertEqual(content['recipe_type'], 'web')
+        self.assertEqual(len(content['collections']), 1)
+        self.assertEqual(content['collections'][0],
+                         {'title': 'test',
+                          'authors': None,
+                          'revised': content['collections'][0]['revised'],
+                          'ident_hash': 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa@1.1',
+                          'link': '/contents/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa@1.1',
+                          'tag': '1.0',
+                          'recipe': '971c419dd609331343dee105fffd0f4608dc0bf2',
+                          'recipe_link': '/resources/971c419dd609331343dee105fffd0f4608dc0bf2',
+                          'status': 'current',
+                          'status_link': '/a/content-status/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+                          })
+
+    def test_print_style_single_no_style(self):
+        request = testing.DummyRequest()
+        print_style = 'fake-print-style'
+        request.matchdict['style'] = print_style
+
+        from ...views.admin import admin_print_styles_single
+        with self.assertRaises(HTTPNotFound) as cm:
+            admin_print_styles_single(request)
+
+        self.assertEqual(cm.exception.message, "Invalid Print Style: fake-print-style")
 
 
 class SiteMessageViewsTestCase(unittest.TestCase):
@@ -247,6 +342,8 @@ class ContentStatusViewsTestCase(unittest.TestCase):
         self.config.include('cnxpublishing.tasks')
         self.config.add_route('admin-content-status-single',
                               '/a/content-status/{uuid}')
+        self.config.add_route('admin-print-style-single',
+                              '/a/print-style/{style}')
         self.config.add_route('get-content', '/contents/{ident_hash}')
         self.config.add_route('get-resource', '/resources/{hash}')
 

--- a/cnxpublishing/views/__init__.py
+++ b/cnxpublishing/views/__init__.py
@@ -59,6 +59,9 @@ def declare_browsable_routes(config):
     add_route('admin-content-status', '/a/content-status/')
     add_route('admin-content-status-single', '/a/content-status/{uuid}')
 
+    add_route('admin-print-style', '/a/print-style/')
+    add_route('admin-print-style-single', '/a/print-style/{style}')
+
 
 def includeme(config):
     """Declare all routes."""

--- a/cnxpublishing/views/admin.py
+++ b/cnxpublishing/views/admin.py
@@ -273,10 +273,161 @@ def admin_edit_site_message_POST(request):
     return args
 
 
+@view_config(route_name='admin-print-style', request_method='GET',
+             renderer='cnxpublishing.views:templates/print-style.html',
+             permission='view')
+def admin_print_styles(request):
+    """
+    Returns a dictionary of all unique print_styles, and their latest tag,
+    revision, and recipe_type.
+    """
+    styles = []
+    # This fetches all recipes that have been used to successfully bake a
+    # current book plus all default recipes that have not yet been used
+    # as well as "bad" books that are not "current" state, but would otherwise
+    # be the latest/current for that book
+    with db_connect(cursor_factory=DictCursor) as db_conn:
+        with db_conn.cursor() as cursor:
+            cursor.execute("""\
+                WITH latest AS (SELECT print_style, recipe,
+                    count(*), count(nullif(stateid, 1)) as bad
+                FROM all_current_modules
+                WHERE portal_type = 'Collection'
+                      AND recipe IS NOT NULL
+                      AND (
+                          baked IS NOT NULL OR (
+                              baked IS NULL AND stateid != 1
+                              )
+                          )
+                GROUP BY print_style, recipe
+                ),
+                defaults AS (SELECT print_style, fileid AS recipe
+                FROM default_print_style_recipes d
+                WHERE not exists (SELECT 1
+                                  FROM latest WHERE latest.recipe = d.fileid)
+                )
+                SELECT coalesce(ps.print_style, '(custom)') as print_style,
+                       ps.title, coalesce(ps.recipe_type, 'web') as type,
+                       ps.revised, ps.tag, ps.commit_id, la.count, la.bad
+                FROM latest la LEFT JOIN print_style_recipes ps ON
+                                    la.print_style = ps.print_style AND
+                                    la.recipe = ps.fileid
+                UNION ALL
+                SELECT ps.print_style, ps.title, ps.recipe_type,
+                       ps.revised, ps.tag, ps.commit_id, 0 AS count, 0 AS bad
+                FROM defaults de JOIN print_style_recipes ps ON
+                                    de.print_style = ps.print_style AND
+                                    de.recipe = ps.fileid
+
+            ORDER BY revised desc NULLS LAST, print_style
+
+                """)
+            for row in cursor.fetchall():
+                styles.append({
+                    'print_style': row['print_style'],
+                    'title': row['title'],
+                    'type': row['type'],
+                    'revised': row['revised'],
+                    'tag': row['tag'],
+                    'commit_id': row['commit_id'],
+                    'number': row['count'],
+                    'bad': row['bad'],
+                    'link': request.route_path('admin-print-style-single',
+                                               style=row['print_style'])
+                })
+    return {'styles': styles}
+
+
+@view_config(route_name='admin-print-style-single', request_method='GET',
+             renderer='cnxpublishing.views:templates/print-style-single.html',
+             permission='view')
+def admin_print_styles_single(request):
+    """ Returns all books with any version of the given print style.
+
+    Returns the print_style, recipe type, num books using the print_style,
+    along with a dictionary of the book, author, revision date, recipe,
+    tag of the print_style, and a link to the content.
+    """
+    style = request.matchdict['style']
+    # do db search to get file id and other info on the print_style
+    with db_connect(cursor_factory=DictCursor) as db_conn:
+        with db_conn.cursor() as cursor:
+
+            if style != '(custom)':
+                cursor.execute("""
+                    SELECT fileid, recipe_type, title
+                    FROM default_print_style_recipes
+                    WHERE print_style=%s
+                    """, vars=(style,))
+                info = cursor.fetchall()
+                if len(info) < 1:
+                    raise httpexceptions.HTTPNotFound(
+                        'Invalid Print Style: {}'.format(style))
+                current_recipe = info[0]['fileid']
+                recipe_type = info[0]['recipe_type']
+                status = 'current'
+
+                cursor.execute("""\
+                    SELECT name, authors, lm.revised, lm.recipe, psr.tag,
+                        f.sha1 as hash, psr.commit_id, uuid,
+                        ident_hash(uuid, major_version, minor_version)
+                    FROM all_current_modules as lm
+                    JOIN print_style_recipes as psr
+                    ON (psr.print_style = lm.print_style and
+                        psr.fileid = lm.recipe)
+                    JOIN files f ON psr.fileid = f.fileid
+                    WHERE lm.print_style=%s
+                    AND portal_type='Collection'
+                    ORDER BY psr.tag DESC;
+                    """, vars=(style,))
+            else:
+                current_recipe = '(custom)'
+                recipe_type = '(custom)'
+                cursor.execute("""\
+                    SELECT name, authors, lm.revised, lm.recipe, NULL as tag,
+                        f.sha1 as hash, NULL as commit_id, uuid,
+                        ident_hash(uuid, major_version, minor_version)
+                    FROM all_current_modules as lm
+                    JOIN files f ON lm.recipe = f.fileid
+                    WHERE portal_type='Collection'
+                    AND NOT EXISTS (
+                        SELECT 1 from print_style_recipes psr
+                        WHERE psr.fileid = lm.recipe)
+                    ORDER BY uuid, recipe, revised DESC;
+                    """, vars=(style,))
+                status = '(custom)'
+
+            collections = []
+            for row in cursor.fetchall():
+                recipe = row['recipe']
+                if status == 'current' and recipe != current_recipe:
+                    status = 'stale'
+                collections.append({
+                    'title': row['name'].decode('utf-8'),
+                    'authors': row['authors'],
+                    'revised': row['revised'],
+                    'recipe': row['hash'],
+                    'recipe_link': request.route_path('get-resource',
+                                                      hash=row['hash']),
+                    'tag': row['tag'],
+                    'ident_hash': row['ident_hash'],
+                    'link': request.route_path('get-content',
+                                               ident_hash=row['ident_hash']),
+                    'status': status,
+                    'status_link': request.route_path(
+                        'admin-content-status-single', uuid=row['uuid']),
+
+                })
+    return {'number': len(collections),
+            'collections': collections,
+            'print_style': style,
+            'recipe_type': recipe_type}
+
+
 def get_baking_statuses_sql(get_request):
     """ Creates SQL to get info on baking books filtered from GET request.
 
-    All books that have ever attmenpted to bake will be retured if they
+    All books that have ever attempted to bake will be retured if they
     pass the filters in the GET request.
     If a single book has been requested to bake multiple times there will
     be a row for each of the baking attempts.
@@ -502,7 +653,6 @@ def admin_content_status_single_POST(request):
         args['response'] = title + ' is not stale, no need to bake'
         return args
 
-    settings = request.registry.settings
     with db_connect() as db_conn:
         with db_conn.cursor() as cursor:
             cursor.execute("SELECT stateid FROM modules WHERE module_ident=%s",

--- a/cnxpublishing/views/admin.py
+++ b/cnxpublishing/views/admin.py
@@ -460,7 +460,6 @@ def get_baking_statuses_sql(get_request):
 
     sql_filters = "WHERE"
     if latest_filter:
-        print latest_filter
         sql_filters += """ ARRAY [m.major_version, m.minor_version] = (
          SELECT max(ARRAY[major_version,minor_version]) FROM
                    modules where m.uuid= uuid) AND """
@@ -495,8 +494,6 @@ def get_baking_statuses_sql(get_request):
                        bpsa.created, bpsa.result_id::text
                 FROM document_baking_result_associations AS bpsa
                 INNER JOIN modules AS m USING (module_ident)
-                LEFT JOIN print_style_recipes as ps
-                    ON ps.print_style=m.print_style
                 LEFT JOIN default_print_style_recipes as dps
                     ON dps.print_style = m.print_style
                 LEFT JOIN print_style_recipes as ps

--- a/cnxpublishing/views/admin.py
+++ b/cnxpublishing/views/admin.py
@@ -461,8 +461,13 @@ def get_baking_statuses_sql(get_request):
         sql_filters = ""
 
     statement = """
-                SELECT m.name, m.authors, m.uuid, m.print_style,
-                       ps.fileid as latest_recipe_id,  m.recipe as recipe_id,
+                SELECT m.name, m.authors, m.uuid,
+                       CASE WHEN f.sha1 IS NOT NULL
+                       THEN coalesce(ps.print_style,'(custom)')
+                       ELSE ps.print_style
+                       END AS print_style,
+                       coalesce(ps.fileid, m.recipe) as latest_recipe_id,
+                       m.recipe as recipe_id,
                        f.sha1 as recipe,
                        module_version(lm.major_version, lm.minor_version)
                         as latest_version,
@@ -533,6 +538,8 @@ def admin_content_status(request):
                     'authors': format_authors(row['authors']),
                     'uuid': row['uuid'],
                     'print_style': row['print_style'],
+                    'print_style_link': request.route_path(
+                        'admin-print-style-single', style=row['print_style']),
                     'recipe': row['recipe'],
                     'recipe_link': request.route_path(
                         'get-resource', hash=row['recipe']),

--- a/cnxpublishing/views/templates/content-status.html
+++ b/cnxpublishing/views/templates/content-status.html
@@ -66,7 +66,7 @@
       <th onclick='sortBooks("m.name")'>Title<i class="{{sort_name}}"></i></th>
       <th>Authors</th>
       <th onclick='sortBooks("STATE")'>State<i class="{{sort_state}}"></i></th>
-      <th>Print Style</th>
+      <th>Recipe Id</th>
       <th>Recipe</th>
       <th>Link to book</th>
       <th>Message</th>
@@ -81,7 +81,13 @@
         <td>
           <i class="{{state.state_icon}}"></i> {{ state.state }}
         </td>
-        <td>{{ state.print_style }}</td>
+        <td>
+          {% if state.print_style %}
+          <a href={{ state.print_style_link }}>{{ state.print_style }}</a>
+          {% else %}
+          None
+          {% endif %}
+        </td>
         <td>
           {% if state.recipe %}
           <a href="{{ state.recipe_link }}">{{ state.recipe }}</a>

--- a/cnxpublishing/views/templates/content-status.html
+++ b/cnxpublishing/views/templates/content-status.html
@@ -63,10 +63,10 @@
   <table>
     <tr>
       <th onclick='sortBooks("bpsa.created")'>Created<i class="{{sort_created}}"></i></th>
-      <th onclick='sortBooks("m.name")'>Title<i class="{{sort_name}}"></i></th>
+      <th onclick='sortBooks("m.name")'>Status Link<i class="{{sort_name}}"></i></th>
       <th>Authors</th>
       <th onclick='sortBooks("STATE")'>State<i class="{{sort_state}}"></i></th>
-      <th>Recipe Id</th>
+      <th>Print Style</th>
       <th>Recipe</th>
       <th>Link to book</th>
       <th>Message</th>
@@ -90,7 +90,7 @@
         </td>
         <td>
           {% if state.recipe %}
-          <a href="{{ state.recipe_link }}">{{ state.recipe }}</a>
+          <a href="{{ state.recipe_link }}">{{ state.recipe_name }} ({{ state.recipe_tag }})</a>
           {% else %}
           None
           {% endif %}

--- a/cnxpublishing/views/templates/content-status.html
+++ b/cnxpublishing/views/templates/content-status.html
@@ -17,6 +17,13 @@
     </div>
 
     <div class="clearfix">
+      <div class="left text-right form-field"><label for="latest">Latest Only:</label></div>
+      <div class="left text-left form-input">
+          <input type="checkbox" name="latest" id="latest" {%if latest_only %}checked="checked"{% endif %} value="latest">
+      </div>
+    </div>
+
+    <div class="clearfix">
       <div class="left text-right form-field"><label for="author">Author:</label></div>
       <div class="left text-left form-input">
         <input type="text" name="author" id="author" value="{{ author }}">

--- a/cnxpublishing/views/templates/print-style-single.html
+++ b/cnxpublishing/views/templates/print-style-single.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %}
+{% block content %}
+  <h1>Print Style: {{print_style}}</h1>
+  <p> Recipie type: {{recipe_type}} </p>
+  <p> Number of Books Using this Style: {{number}}</p>
+  <table>
+    <tr>
+      <th>Title</th>
+      <th>Authors</th>
+      <th>Status</th>
+      <th>Tag</th>
+      <th>Recipe</th>
+      <th>ident_hash</th>
+      <th>Revised</th>
+    </tr>
+    {% for collection in collections %}
+      <tr>
+        <td><a href={{collection.status_link}}>{{ collection.title }}</a></td>
+        <td>{{ collection.authors }}</td>
+        <td>{{ collection.status }}</td>
+        <td>{{ collection.tag }}</td>
+        <td><a href={{ collection.recipe_link }}>{{ collection.recipe }}</a></td>
+        <td><a href={{ collection.link }}>{{ collection.ident_hash }}</a></td>
+        <td>{{ collection.revised }}</td>
+      </tr>
+    {% endfor %}
+  </table>
+{% endblock %}

--- a/cnxpublishing/views/templates/print-style.html
+++ b/cnxpublishing/views/templates/print-style.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+{% block content %}
+  <h1>Print Styles</h1>
+  <br>
+  <table>
+    <tr>
+      <th>Style</th>
+      <th>Title</th>
+      <th>Books</th>
+      <th>Version</th>
+      <th>cnx-recipes commit</th>
+      <th>Deployed</th>
+    </tr>
+    {% for style in styles %}
+      <tr>
+        <td>
+            <a href={{style.link}}>{{ style.print_style }}</a>
+        </td>
+        <td>{{ style.title }}</td>
+        <td>{{ style.number }}{%if style.bad %} ({{ style.bad }}){% endif %}</td>
+        <td>{{ style.tag }}</td>
+        <td>{{ style.commit_id }}</td>
+        <td>
+        {% if style.revised %}
+          {{ style.revised.strftime('%Y-%m-%d %H:%M:%S') }}</td>
+        {% else %}
+          None
+        {% endif %}
+      </tr>
+    {% endfor %}
+  </table>
+{% endblock %}


### PR DESCRIPTION
This  provides updates to the content status views to include links to info about the recipes and print styles, and two print_styles views whih shows similar information, but organized by print style, rather than by book.
![content status with recipes and latest filter](https://user-images.githubusercontent.com/253212/32627938-ccb49824-c559-11e7-911f-3ebe5c2640db.png)

