### PR TITLE
Fix travis test run to use cnx-db env vars

### DIFF
--- a/.travis-compose.yml
+++ b/.travis-compose.yml
@@ -7,3 +7,5 @@ services:
     environment:
       - DB_USER=cnxarchive
       - DB_NAME=cnxarchive-testing
+      - DB_URL=postgresql://cnxarchive@localhost/cnxarchive-testing
+      - DB_SUPER_URL=postgresql://postgres@localhost/cnxarchive-testing


### PR DESCRIPTION
This corrects the travis config to use cnx-db env vars.

This is similar to Connexions/cnx-archive#537