### PR TITLE
Change config files db settings to use postgresql:// urls

### DIFF
--- a/.travis-compose.yml
+++ b/.travis-compose.yml
@@ -7,3 +7,5 @@ services:
     environment:
       - DB_USER=cnxarchive
       - DB_NAME=cnxarchive-testing
+      - DB_URL=postgresql://cnxarchive@localhost/cnxarchive-testing
+      - DB_SUPER_URL=postgresql://postgres@localhost/cnxarchive-testing

--- a/cnxpublishing/tests/conftest.py
+++ b/cnxpublishing/tests/conftest.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 import os
 
-import pytest
 import cnxepub
+import pytest
 from pyramid import testing
 
 from . import use_cases
@@ -14,12 +14,31 @@ def assign_testing_env_vars():
     os.environ['PYRAMID_INI'] = config_uri()
 
 
-# Override cnx-db's connection_string fixture.
+# Override cnx-db's fixture.
+@pytest.fixture
+def db_init_and_wipe(db_engines, db_wipe, db_init):
+    """Combination of the initialization and wiping procedures."""
+    # The argument order, 'wipe' then 'init' is important, because
+    #   db_wipe assumes you want to start with a clean database.
+    # This closes any existing connections, which is sometimes necessary
+    #   because previous connections may not be virtualenv initialized.
+    for engine in db_engines.values():
+        engine.dispose()
+
+
+# Override cnx-db's settings fixture.
 @pytest.fixture(scope='session')
-def db_connection_string():
-    """Returns a connection string"""
+def db_settings():
+    """Returns database connection settings. These settings are provided
+    in a similar format to that of `cnxdb.config.discover_settings`.
+
+    """
     from cnxpublishing.config import CONNECTION_STRING
-    return integration_test_settings()[CONNECTION_STRING]
+    url = integration_test_settings()[CONNECTION_STRING]
+    return {
+        'db.common.url': url,
+        'db.super.url': url,
+    }
 
 
 @pytest.fixture

--- a/cnxpublishing/tests/testing.ini
+++ b/cnxpublishing/tests/testing.ini
@@ -1,6 +1,6 @@
 [app:main]
 use = egg:cnx-publishing
-db-connection-string = dbname=cnxarchive-testing user=cnxarchive password=cnxarchive host=localhost port=5432
+db-connection-string = postgresql://cnxarchive:cnxarchive@localhost:5432/cnxarchive-testing
 # size limit of file uploads in MB
 file_upload_limit = 1
 openstax_accounts.stub = true

--- a/cnxpublishing/tests/testing.py
+++ b/cnxpublishing/tests/testing.py
@@ -70,4 +70,6 @@ def db_connect(method):
 
 def init_db(db_conn_str):
     venv = os.getenv('AS_VENV_IMPORTABLE', 'true').lower() == 'true'
-    _init_db(db_conn_str, venv)
+    from sqlalchemy import create_engine
+    engine = create_engine(db_conn_str)
+    _init_db(engine, venv)

--- a/development.ini
+++ b/development.ini
@@ -17,7 +17,7 @@ pyramid.includes =
 pyramid_sawing.file = %(here)s/logging.yaml
 pyramid_sawing.transit_logging.enabled? = yes
 
-db-connection-string = dbname=cnxarchive user=cnxarchive password=cnxarchive
+db-connection-string = postgresql://cnxarchive:cnxarchive@localhost/cnxarchive
 # size limit of file uploads in MB
 file_upload_limit = 50
 channel_processing.channels = post_publication


### PR DESCRIPTION
Changing the config files to use postgresql:// urls means that we don't need to add code to translate between the postgres dsn string to urls, alternative to #202.