### PR TITLE
Adjust travis config to give cnxarchive role login perms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ install:
   - pip install ".[test]"
 before_script:
   # Give cnxarchive superuser privileges on postgres
-  - docker exec cnxpublishing_db_1 /bin/bash -c "echo 'ALTER USER cnxarchive WITH SUPERUSER' | psql -U postgres postgres"
+  - docker exec cnxpublishing_db_1 /bin/bash -c "echo 'ALTER USER cnxarchive WITH LOGIN SUPERUSER' | psql -U postgres postgres"
   # Stop init_venv from doing anything
   - docker exec cnxpublishing_db_1 /bin/bash -c "echo 'CREATE SCHEMA venv' | psql -U cnxarchive cnxarchive-testing"
   - pip install -U pytest pytest-runner pytest-cov


### PR DESCRIPTION
I'm not sure why this is necessary now when it wasn't before, but it does make it so the master is passing tests again.

This is a similar fix to connexions/cnx-archive#541