### PR TITLE
Adjust the settings for the travis cnx-db container

### DIFF
--- a/.travis-compose.yml
+++ b/.travis-compose.yml
@@ -5,7 +5,7 @@ services:
     ports:
       - "5432:5432"
     environment:
-      - DB_USER=cnxarchive
-      - DB_NAME=cnxarchive-testing
-      - DB_URL=postgresql://cnxarchive@localhost/cnxarchive-testing
-      - DB_SUPER_URL=postgresql://postgres@localhost/cnxarchive-testing
+      - "DB_USER=cnxarchive"
+      - "POSTGRES_DB=cnxarchive-testing"
+      - "DB_URL=postgresql://cnxarchive@localhost/cnxarchive-testing"
+      - "DB_SUPER_URL=postgresql://postgres@localhost/cnxarchive-testing"


### PR DESCRIPTION
This is needed because we dropped the ``DB_NAME`` env var in favor
of the existing ``POSTGRES_DB`` env var.