### PR TITLE
Update README to fix errors on mac

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ System Requirements
 - Memcached
 On OSX:
 
-- the specific version of ``pyicu`` required by `cnx-easybase <https://github.com/Connexions/cnx-easybake>`_ (currently 1.9.8) which you can install by running::
+- the specific version of ``pyicu`` required by `cnx-easybake <https://github.com/Connexions/cnx-easybake>`_ (currently 1.9.8) which you can install by running::
 
     pip install pyicu==1.9.8
 - If you get an ``ImportError`` about ``pyramid_sawing``, run::
@@ -91,6 +91,15 @@ be created using the following commands::
 Install the prerequisite testing package::
 
   pip install pytest pytest-runner pytest-cov testfixtures
+
+Run RabbitMQ (otherwise, all the tests that use it such as ``test_subscribers.py`` will get hungup with no output message at all) with::
+
+    rabbitmq-server
+
+Or run it in the background with::
+
+    brew services start rabbitmq
+
 
 The tests can then be run using::
 
@@ -516,7 +525,7 @@ This process will listen for events and process them as they come in.
 Queued Operations
 -----------------
 
-This application uses the `Celery framework <celeryproject.org>`_ to queue
+This application uses the `Celery framework <http://celeryproject.org>`_ to queue
 work to be done by a worker process. The worker process is run using::
 
   PYRAMID_INI=<your-config.ini celery worker -A cnxpublishing

--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,14 @@ System Requirements
 - PostgreSQL >= 9.4
 - RabbitMQ >= 3.6
 - Memcached
+On OSX:
+
+- the specific version of ``pyicu`` required by `cnx-easybase <https://github.com/Connexions/cnx-easybake>`_ (currently 1.9.8) which you can install by running::
+
+    pip install pyicu==1.9.8
+- If you get an ``ImportError`` about ``pyramid_sawing``, run::
+
+    pip install pyramid_sawing
 
 Getting started
 ---------------


### PR DESCRIPTION
To fix errors raised on OSX:

1. An error about not having the specific version of pyicu installed.
2. An error about not having `pyramid_sawing` installed (which I fixed by running `pip install pyramid_sawing`:

```
$ pserve development.ini 
Traceback (most recent call last):
  File "/usr/local/bin/pserve", line 11, in <module>
    load_entry_point('pyramid==1.9.2', 'console_scripts', 'pserve')()
  File "/usr/local/lib/python2.7/site-packages/pyramid/scripts/pserve.py", line 32, in main
    return command.run()
  File "/usr/local/lib/python2.7/site-packages/pyramid/scripts/pserve.py", line 229, in run
    app = loader.get_wsgi_app(app_name, config_vars)
  File "/usr/local/lib/python2.7/site-packages/plaster_pastedeploy/__init__.py", line 131, in get_wsgi_app
    global_conf=defaults)
  File "/usr/local/Cellar/python@2/2.7.15_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 247, in loadapp
    return loadobj(APP, uri, name=name, **kw)
  File "/usr/local/Cellar/python@2/2.7.15_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 272, in loadobj
    return context.create()
  File "/usr/local/Cellar/python@2/2.7.15_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 710, in create
    return self.object_type.invoke(self)
  File "/usr/local/Cellar/python@2/2.7.15_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 146, in invoke
    return fix_call(context.object, context.global_conf, **context.local_conf)
  File "/usr/local/Cellar/python@2/2.7.15_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/paste/deploy/util.py", line 55, in fix_call
    val = callable(*args, **kw)
  File "/usr/local/lib/python2.7/site-packages/cnxpublishing/main.py", line 29, in make_wsgi_app
    return configure(settings).make_wsgi_app()
  File "/usr/local/lib/python2.7/site-packages/cnxpublishing/config.py", line 67, in configure
    config = Configurator(settings=settings, root_factory=RootFactory)
  File "/usr/local/lib/python2.7/site-packages/pyramid/config/__init__.py", line 345, in __init__
    exceptionresponse_view=exceptionresponse_view,
  File "/usr/local/lib/python2.7/site-packages/pyramid/config/__init__.py", line 463, in setup_registry
    self.include(inc)
  File "/usr/local/lib/python2.7/site-packages/pyramid/config/__init__.py", line 808, in include
    c = self.maybe_dotted(callable)
  File "/usr/local/lib/python2.7/site-packages/pyramid/config/__init__.py", line 912, in maybe_dotted
    return self.name_resolver.maybe_resolve(dotted)
  File "/usr/local/lib/python2.7/site-packages/pyramid/path.py", line 320, in maybe_resolve
    return self._resolve(dotted, package)
  File "/usr/local/lib/python2.7/site-packages/pyramid/path.py", line 327, in _resolve
    return self._zope_dottedname_style(dotted, package)
  File "/usr/local/lib/python2.7/site-packages/pyramid/path.py", line 376, in _zope_dottedname_style
    found = __import__(used)
ImportError: No module named pyramid_sawing
```

3. Also, mention that RabbitMQ must be running for testing.